### PR TITLE
Cleanup all the macro definitions.

### DIFF
--- a/parser-library/parse.h
+++ b/parser-library/parse.h
@@ -29,6 +29,32 @@ THE SOFTWARE.
 
 #include "nt-headers.h"
 
+#define READ_WORD(b, o, inst, member) \
+if(readWord(b, o+_offset(__typeof__(inst), member), inst.member) == false) { \
+  return false; \
+}
+
+#define READ_DWORD(b, o, inst, member) \
+if(readDword(b, o+_offset(__typeof__(inst), member), inst.member) == false) { \
+  return false; \
+}
+
+#define READ_DWORD_PTR(b, o, inst, member) \
+if(readDword(b, o+_offset(__typeof__(*inst), member), inst->member) == false) { \
+  return false; \
+}
+
+#define READ_BYTE(b, o, inst, member) \
+if(readByte(b, o+_offset(__typeof__(inst), member), inst.member) == false) { \
+  return false; \
+}
+
+/* This variant returns NULL instead of false. */
+#define READ_DWORD_NULL(b, o, inst, member) \
+if(readDword(b, o+_offset(__typeof__(inst), member), inst.member) == false) { \
+  return NULL; \
+}
+
 typedef boost::uint32_t RVA;
 typedef boost::uint64_t VA;
 


### PR DESCRIPTION
Instead of constantly defining and redefining the macros to read values
just define them once. There are now the three main ones (READ_WORD,
READ_DWORD and READ_BYTE) along with READ_DWORD_PTR and READ_DWORD_NULL.

Each macro takes a pointer to a bounded_buffer (what to read), an offset
(where to read), a structure and member (what to read into). You should
use READ_DWORD_PTR when you have a pointer to a structure. You can
use READ_DWORD_NULL when failure to read should return NULL as all the
rest return false.

Fixes #7.
