### PR TITLE
Implement PE32+ and error reporting.

### DIFF
--- a/dump-prog/dump.cpp
+++ b/dump-prog/dump.cpp
@@ -29,20 +29,12 @@ THE SOFTWARE.
 using namespace std;
 using namespace boost;
 
-template <class T>
-static
-string to_string(T t, ios_base & (*f)(ios_base&)) {
-    ostringstream oss;
-    oss << f << t;
-    return oss.str();
-}
-
 int printExps(void *N, VA funcAddr, std::string &mod, std::string &func) {
   cout << "EXP: ";
   cout << mod;
   cout << "!";
   cout << func;
-  cout << ":";
+  cout << ": 0x";
   cout << to_string<uint32_t>(funcAddr, hex);
   cout << endl;
   return 0;
@@ -95,16 +87,16 @@ int printRsrc(void     *N,
   if (r.type_str.length())
     cout << "Type (string): " << r.type_str << endl;
   else
-    cout << "Type: " << to_string<uint32_t>(r.type, hex) << endl;
+    cout << "Type: 0x" << to_string<uint32_t>(r.type, hex) << endl;
   if (r.name_str.length())
     cout << "Name (string): " << r.name_str << endl;
   else
-  cout << "Name: " << to_string<uint32_t>(r.name, hex) << endl;
+    cout << "Name: 0x" << to_string<uint32_t>(r.name, hex) << endl;
   if (r.lang_str.length())
     cout << "Lang (string): " << r.lang_str << endl;
   else
-    cout << "Lang: " << to_string<uint32_t>(r.lang, hex) << endl;
-  cout << "Codepage: " << to_string<uint32_t>(r.codepage, hex) << endl;
+    cout << "Lang: 0x" << to_string<uint32_t>(r.lang, hex) << endl;
+  cout << "Codepage: 0x" << to_string<uint32_t>(r.codepage, hex) << endl;
   cout << "RVA: " << to_string<uint32_t>(r.RVA, dec) << endl;
   cout << "Size: " << to_string<uint32_t>(r.size, dec) << endl;
   return 0;
@@ -117,7 +109,7 @@ int printSecs(void                  *N,
               bounded_buffer        *data) 
 {
   cout << "Sec Name: " << secName << endl;
-  cout << "Sec Base: " << to_string<uint64_t>(secBase, hex) << endl;
+  cout << "Sec Base: 0x" << to_string<uint64_t>(secBase, hex) << endl;
   cout << "Sec Size: " << to_string<uint64_t>(data->bufLen, dec) << endl;
   return 0;
 }
@@ -130,45 +122,73 @@ int main(int argc, char *argv[]) {
       //print out some things
 #define DUMP_FIELD(x) \
       cout << "" #x << ": 0x"; \
-      cout << to_string<uint32_t>(p->peHeader.x, hex) << endl;
+      cout << to_string<uint32_t>(p->peHeader.nt.x, hex) << endl;
 #define DUMP_DEC_FIELD(x) \
       cout << "" #x << ": "; \
-      cout << to_string<uint32_t>(p->peHeader.x, dec) << endl;
+      cout << to_string<uint32_t>(p->peHeader.nt.x, dec) << endl;
 
-      DUMP_FIELD(nt.Signature);
-      DUMP_FIELD(nt.FileHeader.Machine);
-      DUMP_FIELD(nt.FileHeader.NumberOfSections);
-      DUMP_DEC_FIELD(nt.FileHeader.TimeDateStamp);
-      DUMP_FIELD(nt.FileHeader.PointerToSymbolTable);
-      DUMP_DEC_FIELD(nt.FileHeader.NumberOfSymbols);
-      DUMP_FIELD(nt.FileHeader.SizeOfOptionalHeader);
-      DUMP_FIELD(nt.FileHeader.Characteristics);
-      DUMP_FIELD(nt.OptionalHeader.Magic);
-      DUMP_DEC_FIELD(nt.OptionalHeader.MajorLinkerVersion);
-      DUMP_DEC_FIELD(nt.OptionalHeader.MinorLinkerVersion);
-      DUMP_FIELD(nt.OptionalHeader.SizeOfCode);
-      DUMP_FIELD(nt.OptionalHeader.SizeOfInitializedData);
-      DUMP_FIELD(nt.OptionalHeader.SizeOfUninitializedData);
-      DUMP_FIELD(nt.OptionalHeader.AddressOfEntryPoint);
-      DUMP_FIELD(nt.OptionalHeader.BaseOfCode);
-      DUMP_FIELD(nt.OptionalHeader.BaseOfData);
-      DUMP_FIELD(nt.OptionalHeader.ImageBase);
-      DUMP_FIELD(nt.OptionalHeader.SectionAlignment);
-      DUMP_FIELD(nt.OptionalHeader.FileAlignment);
-      DUMP_DEC_FIELD(nt.OptionalHeader.MajorOperatingSystemVersion);
-      DUMP_DEC_FIELD(nt.OptionalHeader.MinorOperatingSystemVersion);
-      DUMP_DEC_FIELD(nt.OptionalHeader.Win32VersionValue);
-      DUMP_FIELD(nt.OptionalHeader.SizeOfImage);
-      DUMP_FIELD(nt.OptionalHeader.SizeOfHeaders);
-      DUMP_FIELD(nt.OptionalHeader.CheckSum);
-      DUMP_FIELD(nt.OptionalHeader.Subsystem);
-      DUMP_FIELD(nt.OptionalHeader.DllCharacteristics);
-      DUMP_FIELD(nt.OptionalHeader.SizeOfStackReserve);
-      DUMP_FIELD(nt.OptionalHeader.SizeOfStackCommit);
-      DUMP_FIELD(nt.OptionalHeader.SizeOfHeapReserve);
-      DUMP_FIELD(nt.OptionalHeader.SizeOfHeapCommit);
-      DUMP_FIELD(nt.OptionalHeader.LoaderFlags);
-      DUMP_DEC_FIELD(nt.OptionalHeader.NumberOfRvaAndSizes);
+      DUMP_FIELD(Signature);
+      DUMP_FIELD(FileHeader.Machine);
+      DUMP_FIELD(FileHeader.NumberOfSections);
+      DUMP_DEC_FIELD(FileHeader.TimeDateStamp);
+      DUMP_FIELD(FileHeader.PointerToSymbolTable);
+      DUMP_DEC_FIELD(FileHeader.NumberOfSymbols);
+      DUMP_FIELD(FileHeader.SizeOfOptionalHeader);
+      DUMP_FIELD(FileHeader.Characteristics);
+      if (p->peHeader.nt.OptionalMagic == NT_OPTIONAL_32_MAGIC) {
+        DUMP_FIELD(OptionalHeader.Magic);
+        DUMP_DEC_FIELD(OptionalHeader.MajorLinkerVersion);
+        DUMP_DEC_FIELD(OptionalHeader.MinorLinkerVersion);
+        DUMP_FIELD(OptionalHeader.SizeOfCode);
+        DUMP_FIELD(OptionalHeader.SizeOfInitializedData);
+        DUMP_FIELD(OptionalHeader.SizeOfUninitializedData);
+        DUMP_FIELD(OptionalHeader.AddressOfEntryPoint);
+        DUMP_FIELD(OptionalHeader.BaseOfCode);
+        DUMP_FIELD(OptionalHeader.BaseOfData);
+        DUMP_FIELD(OptionalHeader.ImageBase);
+        DUMP_FIELD(OptionalHeader.SectionAlignment);
+        DUMP_FIELD(OptionalHeader.FileAlignment);
+        DUMP_DEC_FIELD(OptionalHeader.MajorOperatingSystemVersion);
+        DUMP_DEC_FIELD(OptionalHeader.MinorOperatingSystemVersion);
+        DUMP_DEC_FIELD(OptionalHeader.Win32VersionValue);
+        DUMP_FIELD(OptionalHeader.SizeOfImage);
+        DUMP_FIELD(OptionalHeader.SizeOfHeaders);
+        DUMP_FIELD(OptionalHeader.CheckSum);
+        DUMP_FIELD(OptionalHeader.Subsystem);
+        DUMP_FIELD(OptionalHeader.DllCharacteristics);
+        DUMP_FIELD(OptionalHeader.SizeOfStackReserve);
+        DUMP_FIELD(OptionalHeader.SizeOfStackCommit);
+        DUMP_FIELD(OptionalHeader.SizeOfHeapReserve);
+        DUMP_FIELD(OptionalHeader.SizeOfHeapCommit);
+        DUMP_FIELD(OptionalHeader.LoaderFlags);
+        DUMP_DEC_FIELD(OptionalHeader.NumberOfRvaAndSizes);
+      } else {
+        DUMP_FIELD(OptionalHeader64.Magic);
+        DUMP_DEC_FIELD(OptionalHeader64.MajorLinkerVersion);
+        DUMP_DEC_FIELD(OptionalHeader64.MinorLinkerVersion);
+        DUMP_FIELD(OptionalHeader64.SizeOfCode);
+        DUMP_FIELD(OptionalHeader64.SizeOfInitializedData);
+        DUMP_FIELD(OptionalHeader64.SizeOfUninitializedData);
+        DUMP_FIELD(OptionalHeader64.AddressOfEntryPoint);
+        DUMP_FIELD(OptionalHeader64.BaseOfCode);
+        DUMP_FIELD(OptionalHeader64.ImageBase);
+        DUMP_FIELD(OptionalHeader64.SectionAlignment);
+        DUMP_FIELD(OptionalHeader64.FileAlignment);
+        DUMP_DEC_FIELD(OptionalHeader64.MajorOperatingSystemVersion);
+        DUMP_DEC_FIELD(OptionalHeader64.MinorOperatingSystemVersion);
+        DUMP_DEC_FIELD(OptionalHeader64.Win32VersionValue);
+        DUMP_FIELD(OptionalHeader64.SizeOfImage);
+        DUMP_FIELD(OptionalHeader64.SizeOfHeaders);
+        DUMP_FIELD(OptionalHeader64.CheckSum);
+        DUMP_FIELD(OptionalHeader64.Subsystem);
+        DUMP_FIELD(OptionalHeader64.DllCharacteristics);
+        DUMP_FIELD(OptionalHeader64.SizeOfStackReserve);
+        DUMP_FIELD(OptionalHeader64.SizeOfStackCommit);
+        DUMP_FIELD(OptionalHeader64.SizeOfHeapReserve);
+        DUMP_FIELD(OptionalHeader64.SizeOfHeapCommit);
+        DUMP_FIELD(OptionalHeader64.LoaderFlags);
+        DUMP_DEC_FIELD(OptionalHeader64.NumberOfRvaAndSizes);
+      }
 
 #undef DUMP_FIELD
 #undef DUMP_DEC_FIELD
@@ -198,8 +218,13 @@ int main(int argc, char *argv[]) {
         cout << endl;
       }
 
+      cout << "Resources: " << endl;
       IterRsrc(p, printRsrc, NULL);
       DestructParsedPE(p);
+    }
+    else {
+      cout << "Error: " << GetPEErr() << " (" << GetPEErrString() << ")" << endl;
+      cout << "Location: " << GetPEErrLoc() << endl;
     }
   }
   return 0;

--- a/parser-library/nt-headers.h
+++ b/parser-library/nt-headers.h
@@ -35,6 +35,7 @@ const boost::uint16_t MZ_MAGIC = 0x5A4D;
 const boost::uint32_t NT_MAGIC = 0x00004550;
 const boost::uint16_t NUM_DIR_ENTRIES = 16;
 const boost::uint16_t NT_OPTIONAL_32_MAGIC = 0x10B;
+const boost::uint16_t NT_OPTIONAL_64_MAGIC = 0x20B;
 const boost::uint16_t NT_SHORT_NAME_LEN = 8;
 const boost::uint16_t DIR_EXPORT = 0;
 const boost::uint16_t DIR_IMPORT = 1;
@@ -162,10 +163,49 @@ struct optional_header_32 {
   data_directory    DataDirectory[NUM_DIR_ENTRIES];
 };
 
+/*
+ * This is used for PE32+ binaries. It is similar to optional_header_32
+ * except some fields don't exist here (BaseOfData), and others are bigger.
+ */
+struct optional_header_64 {
+  boost::uint16_t   Magic;
+  boost::uint8_t    MajorLinkerVersion;
+  boost::uint8_t    MinorLinkerVersion;
+  boost::uint32_t   SizeOfCode;
+  boost::uint32_t   SizeOfInitializedData;
+  boost::uint32_t   SizeOfUninitializedData;
+  boost::uint32_t   AddressOfEntryPoint;
+  boost::uint32_t   BaseOfCode;
+  boost::uint64_t   ImageBase;
+  boost::uint32_t   SectionAlignment;
+  boost::uint32_t   FileAlignment;
+  boost::uint16_t   MajorOperatingSystemVersion;
+  boost::uint16_t   MinorOperatingSystemVersion;
+  boost::uint16_t   MajorImageVersion;
+  boost::uint16_t   MinorImageVersion;
+  boost::uint16_t   MajorSubsystemVersion;
+  boost::uint16_t   MinorSubsystemVersion;
+  boost::uint32_t   Win32VersionValue;
+  boost::uint32_t   SizeOfImage;
+  boost::uint32_t   SizeOfHeaders;
+  boost::uint32_t   CheckSum;
+  boost::uint16_t   Subsystem;
+  boost::uint16_t   DllCharacteristics;
+  boost::uint64_t   SizeOfStackReserve;
+  boost::uint64_t   SizeOfStackCommit;
+  boost::uint64_t   SizeOfHeapReserve;
+  boost::uint64_t   SizeOfHeapCommit;
+  boost::uint32_t   LoaderFlags;
+  boost::uint32_t   NumberOfRvaAndSizes;
+  data_directory    DataDirectory[NUM_DIR_ENTRIES];
+};
+
 struct nt_header_32 {
   boost::uint32_t     Signature;
   file_header         FileHeader;
   optional_header_32  OptionalHeader;
+  optional_header_64  OptionalHeader64;
+  boost::uint16_t     OptionalMagic;
 };
 
 /*

--- a/python/test.py
+++ b/python/test.py
@@ -7,7 +7,12 @@ import binascii
 
 from hashlib import md5
 
-p = pepy.parse(sys.argv[1])
+try:
+    p = pepy.parse(sys.argv[1])
+except pepy.error as e:
+    print e
+    sys.exit(1)
+
 print "Magic: %s" % hex(p.magic)
 print "Signature: %s" % hex(p.signature)
 print "Machine: %s" % hex(p.machine)
@@ -22,7 +27,11 @@ print "Size of initialized data: %s" % hex(p.initdatasize)
 print "Size of uninitialized data: %s" % hex(p.uninitdatasize)
 print "Address of entry point: %s" % hex(p.entrypointaddr)
 print "Base address of code: %s" % hex(p.baseofcode)
-print "Base address of data: %s" % hex(p.baseofdata)
+try:
+    print "Base address of data: %s" % hex(p.baseofdata)
+except:
+    # Not available on PE32+, ignore it.
+    pass
 print "Image base address: %s" % hex(p.imagebase)
 print "Section alignment: %s" % hex(p.sectionalignement)
 print "File alignment: %s" % hex(p.filealingment)


### PR DESCRIPTION
NOTE: My apologies for putting more than one thing in this pull request.
I was initially going to only add error reporting but when I figured out why
some of my test binaries were failing I just couldn't help myself from adding
support for PE32+. ;)

Teach the parser to properly handle PE32+ binaries.

The major differences are:
- Fields in the OptionalHeader which are not relative are now 64 bits.
- Base addresses should all be 64 bits.
- The BaseOfData field is not available on PE32+

There is now a 16 bit field tacked on to the end of nt_header_32 called
OptionalMagic. This is a duplicate of the Magic field in optional_header_32
and optional_header_64, but is stored in nt_header_32 to make it easier
to determine which optional header is being used.

I also added support for better error reporting. Now when something fails
to parse you can use a couple of functions to find out what happened and
where it happened:
- GetPEErr(): Return the error as an integer.
- GetPEErrString(): Return the error as a string.
- GetPEErrLoc(): Return the function and line number of the error.

Made some changes to pepy to account for these changes. The interface
into pepy is identical. Only externally visible changes are that
pepy.parse() will now return the error string and location when parsing
fails and the baseofdata attribute will throw an exception if the binary
is PE32+.

to_string.h is now included from parse.h, so remove it from dump.cpp.

While here do a bunch of cleanups to make printing consistent. Use '0x'
where appropriate and ensure exceptions are punctuated correctly.
