### PR TITLE
Clear strings.

### DIFF
--- a/parser-library/parse.cpp
+++ b/parser-library/parse.cpp
@@ -249,6 +249,13 @@ bool parse_resource_table(bounded_buffer *sectionData, ::uint32_t o, ::uint32_t 
 
       rsrcs.push_back(rsrc);
     }
+
+    if (depth == 0)
+      rde->type_str.clear();
+    else if (depth == 1)
+      rde->name_str.clear();
+    else if (depth == 2)
+      rde->lang_str.clear();
   }
 
   return true;


### PR DESCRIPTION
This was causing a problem where resources with strings would accumulate
the strings of previous resources in the directory.

For example, here is the output of test.py on
3f0961b7942f12bc96848509c04da2b6:

Resources: (4)
[+] MD5: (191649) 33a6345b919c7c733da9d33ee4ac64eb
    Type string: BINARY
    Name string:
1.165.3106.0_TO_1.165.3138.0_MPASDLTA.VDM._P
    Lang: 0x0
    Codepage: 0x4e4
    RVA: 0x51dc
    Size: 0x2eca1
    First 10 bytes: 0x4d50535091ec0200c263
[+] MD5: (293587) e4c9b9aa65e0b236cb180fa489502700
    Type string: BINARY
    Name string: 1.165.3106.0_TO_1.165.3138.0_MPASDLTA.VDM._P1.165.3106.0_TO_1.165.3138.0_MPAVDLTA.VDM._P

The second resource has the first resources name string in it.