### PR TITLE
Address a problem with invalid sections.

### DIFF
--- a/dump-prog/dump.cpp
+++ b/dump-prog/dump.cpp
@@ -110,7 +110,10 @@ int printSecs(void                  *N,
 {
   cout << "Sec Name: " << secName << endl;
   cout << "Sec Base: 0x" << to_string<uint64_t>(secBase, hex) << endl;
-  cout << "Sec Size: " << to_string<uint64_t>(data->bufLen, dec) << endl;
+  if (data)
+    cout << "Sec Size: " << to_string<uint64_t>(data->bufLen, dec) << endl;
+  else
+    cout << "Sec Size: 0" << endl;
   return 0;
 }
 


### PR DESCRIPTION
I've noticed this in one (otherwise valid) EFI image. What happens is
the section specifies an invalid PointerToRawData, which the bounded
buffer abstraction catches and returns NULL. However, the SizeOfRawData
is still in the structure (and probably invalid too).

I saw two ways to fix this. If sectionData ends up being NULL we can set
SizeOfRawData to 0, but that would be truncating what is otherwise
specified in the file.

The other option is to teach dump-prog and pepy about this and adjust
accordingly. This involves checking for a data being a NULL pointer in
dump-prog when printing sections. In pepy it required roughly the same
check.

I went with option 2.