### PR TITLE
Checking for NumberOfRvaAndSizes to avoid DataDirectory overflow

### DIFF
--- a/parser-library/parse.cpp
+++ b/parser-library/parse.cpp
@@ -382,9 +382,9 @@ bool readOptionalHeader(bounded_buffer *b, optional_header_32 &header) {
   for(::uint32_t i = 0; i < header.NumberOfRvaAndSizes; i++) {
     ::uint32_t  c = (i*sizeof(data_directory));
     c+= _offset(optional_header_32, DataDirectory[0]);
-    
-    ::uint32_t  o = c + _offset(data_directory, VirtualAddress);
+    ::uint32_t  o;
 
+    o = c + _offset(data_directory, VirtualAddress);
     if(readDword(b, o, header.DataDirectory[i].VirtualAddress) == false) {
       return false;
     }
@@ -430,8 +430,8 @@ bool readOptionalHeader64(bounded_buffer *b, optional_header_64 &header) {
   READ_DWORD(b, 0, header, LoaderFlags);
   READ_DWORD(b, 0, header, NumberOfRvaAndSizes);
 
-  if (header.NumberOfRvaAndSizes > 0x100) {
-    return false;
+  if (header.NumberOfRvaAndSizes > NUM_DIR_ENTRIES) {
+    header.NumberOfRvaAndSizes = NUM_DIR_ENTRIES;
   }
 
   for(::uint32_t i = 0; i < header.NumberOfRvaAndSizes; i++) {

--- a/parser-library/parse.cpp
+++ b/parser-library/parse.cpp
@@ -375,12 +375,16 @@ bool readOptionalHeader(bounded_buffer *b, optional_header_32 &header) {
   READ_DWORD(b, 0, header, LoaderFlags);
   READ_DWORD(b, 0, header, NumberOfRvaAndSizes);
 
+  if (header.NumberOfRvaAndSizes > NUM_DIR_ENTRIES) {
+    header.NumberOfRvaAndSizes = NUM_DIR_ENTRIES;
+  }
+
   for(::uint32_t i = 0; i < header.NumberOfRvaAndSizes; i++) {
     ::uint32_t  c = (i*sizeof(data_directory));
     c+= _offset(optional_header_32, DataDirectory[0]);
-    ::uint32_t  o; 
+    
+    ::uint32_t  o = c + _offset(data_directory, VirtualAddress);
 
-    o = c + _offset(data_directory, VirtualAddress);
     if(readDword(b, o, header.DataDirectory[i].VirtualAddress) == false) {
       return false;
     }
@@ -425,6 +429,10 @@ bool readOptionalHeader64(bounded_buffer *b, optional_header_64 &header) {
   READ_QWORD(b, 0, header, SizeOfHeapCommit);
   READ_DWORD(b, 0, header, LoaderFlags);
   READ_DWORD(b, 0, header, NumberOfRvaAndSizes);
+
+  if (header.NumberOfRvaAndSizes > 0x100) {
+    return false;
+  }
 
   for(::uint32_t i = 0; i < header.NumberOfRvaAndSizes; i++) {
     ::uint32_t  c = (i*sizeof(data_directory));


### PR DESCRIPTION
Added a check for the "NumberOfRvaAndSizes" in the optional header to avoid overflows of the DataDirectory array. I discovered this while parsing a large corpus of malware that had samples causing segfaults.