### PR TITLE
Do not use memset on resource_dir_entry. Set fields to 0 manually.

### DIFF
--- a/parser-library/parse.cpp
+++ b/parser-library/parse.cpp
@@ -166,7 +166,11 @@ bool parse_resource_table(bounded_buffer *sectionData, ::uint32_t o, ::uint32_t 
       rde = new resource_dir_entry();
       if (!rde)
         return false;
-      memset(rde, 0, sizeof(*rde));
+      rde->ID = 0;
+      rde->RVA = 0;
+      rde->type = 0;
+      rde->name = 0;
+      rde->lang = 0;
     } else {
       rde = dirent;
     }


### PR DESCRIPTION
Using memset(0) on a resource_dir_entry structure also sets its
std::string members to 0, including their internal datastrucre. This
causes a segmentation fault when assigning them to other strings. This
commit suggests to leave the strings with the default initial values,
and only set the integer values in resource_dir_entry instance to 0.