### PR TITLE
Put all of peparse in the peparse namespace.

### DIFF
--- a/dump-prog/dump.cpp
+++ b/dump-prog/dump.cpp
@@ -28,6 +28,7 @@ THE SOFTWARE.
 
 using namespace std;
 using namespace boost;
+using namespace peparse;
 
 int printExps(void *N, VA funcAddr, std::string &mod, std::string &func) {
   cout << "EXP: ";

--- a/parser-library/buffer.cpp
+++ b/parser-library/buffer.cpp
@@ -38,6 +38,8 @@ THE SOFTWARE.
 using namespace boost;
 using namespace std;
 
+namespace peparse {
+
 extern ::uint32_t err;
 extern ::string err_loc;
 
@@ -266,3 +268,4 @@ void deleteBuffer(bounded_buffer *b) {
 uint64_t bufLen(bounded_buffer *b) {
   return b->bufLen;
 }
+} // namespace peparse

--- a/parser-library/nt-headers.h
+++ b/parser-library/nt-headers.h
@@ -31,6 +31,7 @@ THE SOFTWARE.
 //need to pack these structure definitions
 
 //some constant definitions
+namespace peparse {
 const boost::uint16_t MZ_MAGIC = 0x5A4D;
 const boost::uint32_t NT_MAGIC = 0x00004550;
 const boost::uint16_t NUM_DIR_ENTRIES = 16;
@@ -307,5 +308,6 @@ struct reloc_block {
   boost::uint32_t PageRVA;
   boost::uint32_t BlockSize;
 };
+} // namespace peparse
 
 #endif

--- a/parser-library/parse.cpp
+++ b/parser-library/parse.cpp
@@ -34,6 +34,8 @@ THE SOFTWARE.
 using namespace std;
 using namespace boost;
 
+namespace peparse {
+
 struct section {
   string                sectionName;
   ::uint64_t            sectionBase;
@@ -1489,3 +1491,4 @@ bool GetEntryPoint(parsed_pe *pe, VA &v) {
 
   return false;
 }
+} // namespace peparse

--- a/parser-library/parse.h
+++ b/parser-library/parse.h
@@ -72,6 +72,8 @@ if(readDword(b, o+_offset(__typeof__(inst), member), inst.member) == false) { \
   return NULL; \
 }
 
+namespace peparse {
+
 typedef boost::uint32_t RVA;
 typedef boost::uint64_t VA;
 
@@ -197,5 +199,6 @@ bool ReadByteAtVA(parsed_pe *pe, VA v, boost::uint8_t &b);
 
 //get entry point into PE
 bool GetEntryPoint(parsed_pe *pe, VA &v);
+} // namespace peparse
 
 #endif

--- a/parser-library/to_string.h
+++ b/parser-library/to_string.h
@@ -2,11 +2,13 @@
 #define _TO_STRING_H
 #include <sstream>
 
+namespace peparse {
 template <class T>
 static
 std::string to_string(T t, std::ios_base & (*f)(std::ios_base&)) {
     std::ostringstream oss;
     oss << f << t;
     return oss.str();
+}
 }
 #endif

--- a/python/pepy.cpp
+++ b/python/pepy.cpp
@@ -29,6 +29,8 @@
 #include <structmember.h>
 #include "parse.h"
 
+using namespace peparse;
+
 #define PEPY_VERSION "0.2"
 
 /* These are used to across multiple objects. */


### PR DESCRIPTION
* Fixes dupicate symbol problems when using the library inside other applications, namely Python
* Should fix #25