### PR TITLE
fixed header collisions when windows.h included

### DIFF
--- a/dump-pe/main.cpp
+++ b/dump-pe/main.cpp
@@ -62,7 +62,7 @@ int printRelocs(void *N, VA relocAddr, reloc_type type) {
 
   std::cout << "TYPE: ";
   switch (type) {
-    case ABSOLUTE:
+    case ABS:
       std::cout << "ABSOLUTE";
       break;
     case HIGH:

--- a/pe-parser-library/include/parser-library/nt-headers.h
+++ b/pe-parser-library/include/parser-library/nt-headers.h
@@ -59,143 +59,20 @@ constexpr std::uint16_t DIR_IAT = 12;
 constexpr std::uint16_t DIR_DELAY_IMPORT = 13;
 constexpr std::uint16_t DIR_COM_DESCRIPTOR = 14;
 
-// Machine Types
-constexpr std::uint16_t IMAGE_FILE_MACHINE_UNKNOWN = 0x0;
-constexpr std::uint16_t IMAGE_FILE_MACHINE_AM33 = 0x1d3;      // Matsushita AM33
-constexpr std::uint16_t IMAGE_FILE_MACHINE_AMD64 = 0x8664;    // x64
-constexpr std::uint16_t IMAGE_FILE_MACHINE_ARM = 0x1c0;       // ARM little endian
-constexpr std::uint16_t IMAGE_FILE_MACHINE_ARM64 = 0xaa64;    // ARM64 little endian
-constexpr std::uint16_t IMAGE_FILE_MACHINE_ARMNT = 0x1c4;     // ARM Thumb-2 little endian
-constexpr std::uint16_t IMAGE_FILE_MACHINE_EBC = 0xebc;       // EFI byte code
-constexpr std::uint16_t IMAGE_FILE_MACHINE_I386 = 0x14c;      // Intel 386 or later processors and compatible processors
-constexpr std::uint16_t IMAGE_FILE_MACHINE_IA64 = 0x200;      // Intel Itanium processor family
-constexpr std::uint16_t IMAGE_FILE_MACHINE_M32R = 0x9041;     // Mitsubishi M32R little endian
-constexpr std::uint16_t IMAGE_FILE_MACHINE_MIPS16 = 0x266;    // MIPS16
-constexpr std::uint16_t IMAGE_FILE_MACHINE_MIPSFPU = 0x366;   // MIPS with FPU
-constexpr std::uint16_t IMAGE_FILE_MACHINE_MIPSFPU16 = 0x466; // MIPS16 with FPU
-constexpr std::uint16_t IMAGE_FILE_MACHINE_POWERPC = 0x1f0;   // Power PC little endian
-constexpr std::uint16_t IMAGE_FILE_MACHINE_POWERPCFP = 0x1f1; // Power PC with floating point support
-constexpr std::uint16_t IMAGE_FILE_MACHINE_R4000 = 0x166;     // MIPS little endian
+
 constexpr std::uint16_t IMAGE_FILE_MACHINE_RISCV32 = 0x5032;  // RISC-V 32-bit address space
 constexpr std::uint16_t IMAGE_FILE_MACHINE_RISCV64 = 0x5064;  // RISC-V 64-bit address space
 constexpr std::uint16_t IMAGE_FILE_MACHINE_RISCV128 = 0x5128; // RISC-V 128-bit address space
-constexpr std::uint16_t IMAGE_FILE_MACHINE_SH3 = 0x1a2;       // Hitachi SH3
-constexpr std::uint16_t IMAGE_FILE_MACHINE_SH3DSP = 0x1a3;    // Hitachi SH3 DSP
-constexpr std::uint16_t IMAGE_FILE_MACHINE_SH4 = 0x1a6;       // Hitachi SH4
-constexpr std::uint16_t IMAGE_FILE_MACHINE_SH5 = 0x1a8;       // Hitachi SH5
-constexpr std::uint16_t IMAGE_FILE_MACHINE_THUMB = 0x1c2;     // Thumb
-constexpr std::uint16_t IMAGE_FILE_MACHINE_WCEMIPSV2 = 0x169; // MIPS little-endian WCE v2
 
-constexpr std::uint16_t IMAGE_FILE_RELOCS_STRIPPED = 0x0001;
-constexpr std::uint16_t IMAGE_FILE_EXECUTABLE_IMAGE = 0x0002;
-constexpr std::uint16_t IMAGE_FILE_LINE_NUMS_STRIPPED = 0x0004;
-constexpr std::uint16_t IMAGE_FILE_LOCAL_SYMS_STRIPPED = 0x0008;
+
+
 constexpr std::uint16_t IMAGE_FILE_AGGRESSIVE_WS_TRIM = 0x0010;
-constexpr std::uint16_t IMAGE_FILE_LARGE_ADDRESS_AWARE = 0x0020;
-constexpr std::uint16_t IMAGE_FILE_BYTES_REVERSED_LO = 0x0080;
-constexpr std::uint16_t IMAGE_FILE_32BIT_MACHINE = 0x0100;
-constexpr std::uint16_t IMAGE_FILE_DEBUG_STRIPPED = 0x0200;
-constexpr std::uint16_t IMAGE_FILE_REMOVABLE_RUN_FROM_SWAP = 0x0400;
-constexpr std::uint16_t IMAGE_FILE_NET_RUN_FROM_SWAP = 0x0800;
-constexpr std::uint16_t IMAGE_FILE_SYSTEM = 0x1000;
-constexpr std::uint16_t IMAGE_FILE_DLL = 0x2000;
-constexpr std::uint16_t IMAGE_FILE_UP_SYSTEM_ONLY = 0x4000;
-constexpr std::uint16_t IMAGE_FILE_BYTES_REVERSED_HI = 0x8000;
-
-constexpr std::uint32_t IMAGE_SCN_TYPE_NO_PAD = 0x00000008;
-constexpr std::uint32_t IMAGE_SCN_CNT_CODE = 0x00000020;
-constexpr std::uint32_t IMAGE_SCN_CNT_INITIALIZED_DATA = 0x00000040;
-constexpr std::uint32_t IMAGE_SCN_CNT_UNINITIALIZED_DATA = 0x00000080;
-constexpr std::uint32_t IMAGE_SCN_LNK_OTHER = 0x00000100;
-constexpr std::uint32_t IMAGE_SCN_LNK_INFO = 0x00000200;
-constexpr std::uint32_t IMAGE_SCN_LNK_REMOVE = 0x00000800;
-constexpr std::uint32_t IMAGE_SCN_LNK_COMDAT = 0x00001000;
-constexpr std::uint32_t IMAGE_SCN_NO_DEFER_SPEC_EXC = 0x00004000;
-constexpr std::uint32_t IMAGE_SCN_GPREL = 0x00008000;
-constexpr std::uint32_t IMAGE_SCN_MEM_FARDATA = 0x00008000;
-constexpr std::uint32_t IMAGE_SCN_MEM_PURGEABLE = 0x00020000;
-constexpr std::uint32_t IMAGE_SCN_MEM_16BIT = 0x00020000;
-constexpr std::uint32_t IMAGE_SCN_MEM_LOCKED = 0x00040000;
-constexpr std::uint32_t IMAGE_SCN_MEM_PRELOAD = 0x00080000;
-constexpr std::uint32_t IMAGE_SCN_ALIGN_1BYTES = 0x00100000;
-constexpr std::uint32_t IMAGE_SCN_ALIGN_2BYTES = 0x00200000;
-constexpr std::uint32_t IMAGE_SCN_ALIGN_4BYTES = 0x00300000;
-constexpr std::uint32_t IMAGE_SCN_ALIGN_8BYTES = 0x00400000;
-constexpr std::uint32_t IMAGE_SCN_ALIGN_16BYTES = 0x00500000;
-constexpr std::uint32_t IMAGE_SCN_ALIGN_32BYTES = 0x00600000;
-constexpr std::uint32_t IMAGE_SCN_ALIGN_64BYTES = 0x00700000;
-constexpr std::uint32_t IMAGE_SCN_ALIGN_128BYTES = 0x00800000;
-constexpr std::uint32_t IMAGE_SCN_ALIGN_256BYTES = 0x00900000;
-constexpr std::uint32_t IMAGE_SCN_ALIGN_512BYTES = 0x00A00000;
-constexpr std::uint32_t IMAGE_SCN_ALIGN_1024BYTES = 0x00B00000;
-constexpr std::uint32_t IMAGE_SCN_ALIGN_2048BYTES = 0x00C00000;
-constexpr std::uint32_t IMAGE_SCN_ALIGN_4096BYTES = 0x00D00000;
-constexpr std::uint32_t IMAGE_SCN_ALIGN_8192BYTES = 0x00E00000;
-constexpr std::uint32_t IMAGE_SCN_ALIGN_MASK = 0x00F00000;
-constexpr std::uint32_t IMAGE_SCN_LNK_NRELOC_OVFL = 0x01000000;
-constexpr std::uint32_t IMAGE_SCN_MEM_DISCARDABLE = 0x02000000;
-constexpr std::uint32_t IMAGE_SCN_MEM_NOT_CACHED = 0x04000000;
-constexpr std::uint32_t IMAGE_SCN_MEM_NOT_PAGED = 0x08000000;
-constexpr std::uint32_t IMAGE_SCN_MEM_SHARED = 0x10000000;
-constexpr std::uint32_t IMAGE_SCN_MEM_EXECUTE = 0x20000000;
-constexpr std::uint32_t IMAGE_SCN_MEM_READ = 0x40000000;
-constexpr std::uint32_t IMAGE_SCN_MEM_WRITE = 0x80000000;
-
-// Symbol section number values
-constexpr std::int16_t IMAGE_SYM_UNDEFINED = 0;
-constexpr std::int16_t IMAGE_SYM_ABSOLUTE = -1;
-constexpr std::int16_t IMAGE_SYM_DEBUG = -2;
 
 // Symbol table types
-constexpr std::uint16_t IMAGE_SYM_TYPE_NULL = 0;
-constexpr std::uint16_t IMAGE_SYM_TYPE_VOID = 1;
-constexpr std::uint16_t IMAGE_SYM_TYPE_CHAR = 2;
-constexpr std::uint16_t IMAGE_SYM_TYPE_SHORT = 3;
-constexpr std::uint16_t IMAGE_SYM_TYPE_INT = 4;
-constexpr std::uint16_t IMAGE_SYM_TYPE_LONG = 5;
-constexpr std::uint16_t IMAGE_SYM_TYPE_FLOAT = 6;
-constexpr std::uint16_t IMAGE_SYM_TYPE_DOUBLE = 7;
-constexpr std::uint16_t IMAGE_SYM_TYPE_STRUCT = 8;
-constexpr std::uint16_t IMAGE_SYM_TYPE_UNION = 9;
-constexpr std::uint16_t IMAGE_SYM_TYPE_ENUM = 10;
-constexpr std::uint16_t IMAGE_SYM_TYPE_MOE = 11;
-constexpr std::uint16_t IMAGE_SYM_TYPE_BYTE = 12;
-constexpr std::uint16_t IMAGE_SYM_TYPE_WORD = 13;
-constexpr std::uint16_t IMAGE_SYM_TYPE_UINT = 14;
-constexpr std::uint16_t IMAGE_SYM_TYPE_DWORD = 15;
-constexpr std::uint16_t IMAGE_SYM_DTYPE_NULL = 0;
-constexpr std::uint16_t IMAGE_SYM_DTYPE_POINTER = 1;
-constexpr std::uint16_t IMAGE_SYM_DTYPE_FUNCTION = 2;
-constexpr std::uint16_t IMAGE_SYM_DTYPE_ARRAY = 3;
+
 
 // Symbol table storage classes
-constexpr std::uint8_t IMAGE_SYM_CLASS_END_OF_FUNCTION = static_cast<const std::uint8_t>(-1);
-constexpr std::uint8_t IMAGE_SYM_CLASS_NULL = 0;
-constexpr std::uint8_t IMAGE_SYM_CLASS_AUTOMATIC = 1;
-constexpr std::uint8_t IMAGE_SYM_CLASS_EXTERNAL = 2;
-constexpr std::uint8_t IMAGE_SYM_CLASS_STATIC = 3;
-constexpr std::uint8_t IMAGE_SYM_CLASS_REGISTER = 4;
-constexpr std::uint8_t IMAGE_SYM_CLASS_EXTERNAL_DEF = 5;
-constexpr std::uint8_t IMAGE_SYM_CLASS_LABEL = 6;
-constexpr std::uint8_t IMAGE_SYM_CLASS_UNDEFINED_LABEL = 7;
-constexpr std::uint8_t IMAGE_SYM_CLASS_MEMBER_OF_STRUCT = 8;
-constexpr std::uint8_t IMAGE_SYM_CLASS_ARGUMENT = 9;
-constexpr std::uint8_t IMAGE_SYM_CLASS_STRUCT_TAG = 10;
-constexpr std::uint8_t IMAGE_SYM_CLASS_MEMBER_OF_UNION = 11;
-constexpr std::uint8_t IMAGE_SYM_CLASS_UNION_TAG = 12;
-constexpr std::uint8_t IMAGE_SYM_CLASS_TYPE_DEFINITION = 13;
-constexpr std::uint8_t IMAGE_SYM_CLASS_UNDEFINED_STATIC = 14;
-constexpr std::uint8_t IMAGE_SYM_CLASS_ENUM_TAG = 15;
-constexpr std::uint8_t IMAGE_SYM_CLASS_MEMBER_OF_ENUM = 16;
-constexpr std::uint8_t IMAGE_SYM_CLASS_REGISTER_PARAM = 17;
-constexpr std::uint8_t IMAGE_SYM_CLASS_BIT_FIELD = 18;
-constexpr std::uint8_t IMAGE_SYM_CLASS_BLOCK = 100;
-constexpr std::uint8_t IMAGE_SYM_CLASS_FUNCTION = 101;
-constexpr std::uint8_t IMAGE_SYM_CLASS_END_OF_STRUCT = 102;
-constexpr std::uint8_t IMAGE_SYM_CLASS_FILE = 103;
-constexpr std::uint8_t IMAGE_SYM_CLASS_SECTION = 104;
-constexpr std::uint8_t IMAGE_SYM_CLASS_WEAK_EXTERNAL = 105;
-constexpr std::uint8_t IMAGE_SYM_CLASS_CLR_TOKEN = 107;
+
 // clang-format on
 
 struct dos_header {
@@ -356,7 +233,7 @@ struct resource_dat_entry {
 };
 
 struct image_section_header {
-  std::uint8_t Name[NT_SHORT_NAME_LEN];
+  std::uint8_t Name[8];
   union {
     std::uint32_t PhysicalAddress;
     std::uint32_t VirtualSize;
@@ -394,7 +271,7 @@ struct export_dir_table {
 };
 
 enum reloc_type {
-  ABSOLUTE = 0,
+  ABS = 0,
   HIGH = 1,
   LOW = 2,
   HIGHLOW = 3,

--- a/pe-parser-library/include/parser-library/parse.h
+++ b/pe-parser-library/include/parser-library/parse.h
@@ -27,6 +27,9 @@ THE SOFTWARE.
 #include <cstdint>
 #include <string>
 
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 #include "nt-headers.h"
 #include "to_string.h"
 
@@ -96,31 +99,6 @@ struct resource {
   std::uint32_t RVA;
   std::uint32_t size;
   bounded_buffer *buf;
-};
-
-// http://msdn.microsoft.com/en-us/library/ms648009(v=vs.85).aspx
-enum resource_type {
-  RT_CURSOR = 1,
-  RT_BITMAP = 2,
-  RT_ICON = 3,
-  RT_MENU = 4,
-  RT_DIALOG = 5,
-  RT_STRING = 6,
-  RT_FONTDIR = 7,
-  RT_FONT = 8,
-  RT_ACCELERATOR = 9,
-  RT_RCDATA = 10,
-  RT_MESSAGETABLE = 11,
-  RT_GROUP_CURSOR = 12, // MAKEINTRESOURCE((ULONG_PTR)(RT_CURSOR) + 11)
-  RT_GROUP_ICON = 14,   // MAKEINTRESOURCE((ULONG_PTR)(RT_ICON) + 11)
-  RT_VERSION = 16,
-  RT_DLGINCLUDE = 17,
-  RT_PLUGPLAY = 19,
-  RT_VXD = 20,
-  RT_ANICURSOR = 21,
-  RT_ANIICON = 22,
-  RT_HTML = 23,
-  RT_MANIFEST = 24
 };
 
 enum pe_err {


### PR DESCRIPTION
On windows if winnt.h is already included then all the defs in nt-headers collide and give > 100 errors. Here are the minimal windows changes needed to fix this. This will probably break linux, so probably best to do an ifdef on the platform being compiled. This was how i chose to fix it because i already use windows.h, there's probably a better option but that is up to you all.

Your build docs for windows should also not us DCMAKE flag instead use config

build all from command line:
```
cmake -G "Visual Studio 15 2017"
cmake --build . // for debug
cmake --build . --config Release // for release
```

if building from .sln then just use -G and set the config mode using visual studio gui.