### PR TITLE
Fix Windows build and VS2017 compiler errors for example project

### DIFF
--- a/examples/peaddrconv/CMakeLists.txt
+++ b/examples/peaddrconv/CMakeLists.txt
@@ -1,15 +1,21 @@
 cmake_minimum_required(VERSION 3.1)
 project(peaddrconv)
 
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "Default install directory" FORCE)
+endif ()
+
 if (MSVC)
-  list(APPEND PEADDRCONV_CXXFLAGS /W4 /analyze)
+  # Default CMAKE_PREFIX_PATH is empty and CMAKE_SYSTEM_PREFIX_PATH is
+  # set to a list of Program Files directories, which is a problem because
+  # pe-parser-library (by default) installs itself to `%SystemDrive%\usr`
+  # directory on Windows its not found by CMake when performing its search.
+  list(APPEND CMAKE_PREFIX_PATH /usr/lib/cmake)
+
+  list(APPEND PEADDRCONV_CXXFLAGS /W4 /WX /analyze)
 
   if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     list(APPEND PEADDRCONV_CXXFLAGS /Zi)
-  endif ()
-
-  if (CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-    list(APPEND PEADDRCONV_CXXFLAGS /WX)
   endif ()
 
 else ()
@@ -33,7 +39,7 @@ find_package(peparse REQUIRED)
 
 add_executable(${PROJECT_NAME} main.cpp)
 target_link_libraries(${PROJECT_NAME} ${PEPARSE_LIBRARIES})
-target_include_directories(${PROJECT_NAME} PRIVATE ${PEPARSE_INCLUDE_DIRS})
+target_include_directories(${PROJECT_NAME} PRIVATE ${PEPARSE_INCLUDE_DIR})
 target_compile_options(${PROJECT_NAME} PRIVATE ${PEADDRCONV_CXXFLAGS})
 
 install(TARGETS ${PROJECT_NAME} DESTINATION "bin")

--- a/examples/peaddrconv/README.md
+++ b/examples/peaddrconv/README.md
@@ -1,1 +1,3 @@
-Note that you have to install the library before you can build this example!
+Note that you have to install the library before you can build this example,
+which is done by running `cmake --build . --config Release --target install`
+(noted as optional in the library [README](../../README.md#building)).

--- a/examples/peaddrconv/main.cpp
+++ b/examples/peaddrconv/main.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <algorithm>
 
 #include <climits>
 #include <cstring>
@@ -28,10 +29,10 @@ enum class AddressType {
 };
 
 bool convertAddress(ParsedPeRef &pe,
-                    std::uintptr_t address,
+                    std::uint64_t address,
                     AddressType source_type,
                     AddressType destination_type,
-                    std::uintptr_t &result) noexcept {
+                    std::uint64_t &result) noexcept {
   if (source_type == destination_type) {
     result = address;
     return true;
@@ -107,8 +108,8 @@ bool convertAddress(ParsedPeRef &pe,
       if (destination_type == AddressType::RelativeVirtualAddress) {
         struct CallbackData final {
           bool found;
-          std::uintptr_t address;
-          std::uintptr_t result;
+          std::uint64_t address;
+          std::uint64_t result;
         };
 
         auto L_inspectSection = [](void *N,
@@ -153,7 +154,7 @@ bool convertAddress(ParsedPeRef &pe,
         return true;
 
       } else if (destination_type == AddressType::VirtualAddress) {
-        std::uintptr_t rva = 0U;
+        std::uint64_t rva = 0U;
         if (!convertAddress(pe,
                             address,
                             source_type,
@@ -180,8 +181,8 @@ bool convertAddress(ParsedPeRef &pe,
       if (destination_type == AddressType::PhysicalOffset) {
         struct CallbackData final {
           bool found;
-          std::uintptr_t address;
-          std::uintptr_t result;
+          std::uint64_t address;
+          std::uint64_t result;
         };
 
         auto L_inspectSection = [](void *N,
@@ -234,7 +235,7 @@ bool convertAddress(ParsedPeRef &pe,
         return false;
       }
 
-      std::uintptr_t rva = address - image_base_address;
+      std::uint64_t rva = address - image_base_address;
       return convertAddress(pe,
                             rva,
                             AddressType::RelativeVirtualAddress,
@@ -261,7 +262,7 @@ int main(int argc, char *argv[]) {
   char *last_parsed_char = nullptr;
   errno = 0;
 
-  auto address = std::strtoull(address_as_string, &last_parsed_char, 16);
+  std::uint64_t address = std::strtoull(address_as_string, &last_parsed_char, 16);
   if (address == 0U && *last_parsed_char != 0) {
     std::cout << "Invalid address specified\n";
     return 1;
@@ -293,7 +294,7 @@ int main(int argc, char *argv[]) {
             << "\n";
   std::cout << "Converting address 0x" << std::hex << address << "...\n\n";
 
-  std::uintptr_t result = 0U;
+  std::uint64_t result = 0U;
 
   std::cout << "as Physical offset (off)\n";
   std::cout << "  to rva:\t";


### PR DESCRIPTION
Example doesn't compile in Windows using VS2017 compiler.

Fixes:
* Unable to find the installation path to pe-parser-library when it has been installed following the procedure in the docs
* Typo preventing include files from being found. This didn't seem to affect Linux builds because the headers install to a default path
* Compiler error about `std::min` and `std::max` not found in the std namespace
* Compiler warnings regarding possible loss of data when converting from `std::uint64_t` to `std::uintptr_t`
* Treat compiler warnings as errors in all build profiles

Related to #50.