### PR TITLE
Parse TLS data directory

### DIFF
--- a/dump-pe/main.cpp
+++ b/dump-pe/main.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 */
 
 #include <iostream>
+#include <iomanip>
 #include <sstream>
 #include <cstring>
 
@@ -40,7 +41,7 @@ int printExps(void *N, VA funcAddr, std::string &mod, std::string &func) {
   std::cout << "!";
   std::cout << func;
   std::cout << ": 0x";
-  std::cout << to_string<decltype(address)>(address, std::hex);
+  std::cout << std::hex << address;
   std::cout << "\n";
   return 0;
 }
@@ -53,8 +54,7 @@ int printImports(void *N,
 
   auto address = static_cast<std::uint32_t>(impAddr);
 
-  std::cout << "0x" << to_string<decltype(address)>(address, std::hex);
-  std::cout << " " << modName << "!" << symName;
+  std::cout << "0x" << std::hex << address << " " << modName << "!" << symName;
   std::cout << "\n";
   return 0;
 }
@@ -93,7 +93,7 @@ int printRelocs(void *N, VA relocAddr, reloc_type type) {
       break;
   }
 
-  std::cout << " VA: 0x" << to_string<VA>(relocAddr, std::hex) << "\n";
+  std::cout << " VA: 0x" << std::hex << relocAddr << "\n";
 
   return 0;
 }
@@ -108,8 +108,7 @@ int printSymbols(void *N,
   static_cast<void>(N);
 
   std::cout << "Symbol Name: " << strName << "\n";
-  std::cout << "Symbol Value: 0x"
-            << to_string<std::uint32_t>(value, std::hex) << "\n";
+  std::cout << "Symbol Value: 0x" << std::hex << value << "\n";
 
   std::cout << "Symbol Section Number: ";
   switch (sectionNumber) {
@@ -234,22 +233,21 @@ int printRsrc(void *N, resource r) {
   if (r.type_str.length())
     std::cout << "Type (string): " << r.type_str << "\n";
   else
-    std::cout << "Type: 0x"
-              << to_string<std::uint32_t>(r.type, std::hex) << "\n";
+    std::cout << "Type: 0x" << std::hex << r.type << "\n";
+
   if (r.name_str.length())
     std::cout << "Name (string): " << r.name_str << "\n";
   else
-    std::cout << "Name: 0x"
-              << to_string<std::uint32_t>(r.name, std::hex) << "\n";
+    std::cout << "Name: 0x" << std::hex << r.name << "\n";
+
   if (r.lang_str.length())
     std::cout << "Lang (string): " << r.lang_str << "\n";
   else
-    std::cout << "Lang: 0x"
-              << to_string<std::uint32_t>(r.lang, std::hex) << "\n";
-  std::cout << "Codepage: 0x"
-            << to_string<std::uint32_t>(r.codepage, std::hex) << "\n";
-  std::cout << "RVA: " << to_string<std::uint32_t>(r.RVA, std::dec) << "\n";
-  std::cout << "Size: " << to_string<std::uint32_t>(r.size, std::dec) << "\n";
+    std::cout << "Lang: 0x" << std::hex << r.lang << "\n";
+
+  std::cout << "Codepage: 0x" << std::hex << r.codepage << "\n";
+  std::cout << "RVA: " << std::dec << r.RVA << "\n";
+  std::cout << "Size: " << std::dec << r.size << "\n";
   return 0;
 }
 
@@ -262,11 +260,9 @@ int printSecs(void *N,
   static_cast<void>(s);
 
   std::cout << "Sec Name: " << secName << "\n";
-  std::cout << "Sec Base: 0x"
-            << to_string<std::uint64_t>(secBase, std::hex) << "\n";
+  std::cout << "Sec Base: 0x" << std::hex << secBase << "\n";
   if (data)
-    std::cout << "Sec Size: "
-              << to_string<std::uint64_t>(data->bufLen, std::dec) << "\n";
+    std::cout << "Sec Size: " << std::dec << data->bufLen << "\n";
   else
     std::cout << "Sec Size: 0" << "\n";
   return 0;
@@ -275,9 +271,7 @@ int printSecs(void *N,
 int printTls(void *N, VA funcAddr) {
   static_cast<void>(N);
   auto address = static_cast<std::uint64_t>(funcAddr);
-  std::cout << "TLS: 0x";
-  std::cout << to_string<decltype(address)>(address, std::hex);
-  std::cout << "\n";
+  std::cout << "TLS: 0x" << std::hex << address << "\n";
   return 0;
 }
 
@@ -285,26 +279,25 @@ int printTlsWithBinary(void *N, VA funcAddr) {
   parsed_pe *p = static_cast<parsed_pe*>(N);
   auto address = static_cast<std::uint64_t>(funcAddr);
   std::cout << "First 8 bytes from tls callback (0x";
-  std::cout << to_string<VA>(address, std::hex);
-  std::cout << "):" << "\n";
+  std::cout << std::hex << address << "):" << "\n";
+
   for (std::size_t i = 0; i < 8; i++) {
     std::uint8_t b;
     ReadByteAtVA(p, i + address, b);
-    std::cout << " 0x" << to_string<uint64_t>(b, std::hex);
+    std::cout << " 0x" << std::hex << static_cast<int>(b);
   }
+
   std::cout << "\n";
   return 0;
 }
 
-#define DUMP_FIELD(x)                                                      \
-  std::cout << "" #x << ": 0x";                                            \
-  std::cout << to_string<std::uint64_t>(                                   \
-                   static_cast<std::uint64_t>(p->peHeader.nt.x), std::hex) \
+#define DUMP_FIELD(x)                                                   \
+  std::cout << "" #x << ": 0x";                                         \
+  std::cout << std::hex << static_cast<std::uint64_t>(p->peHeader.nt.x) \
             << "\n";
-#define DUMP_DEC_FIELD(x)                                                  \
-  std::cout << "" #x << ": ";                                              \
-  std::cout << to_string<std::uint64_t>(                                   \
-                   static_cast<std::uint64_t>(p->peHeader.nt.x), std::dec) \
+#define DUMP_DEC_FIELD(x)                                               \
+  std::cout << "" #x << ": ";                                           \
+  std::cout << std::dec << static_cast<std::uint64_t>(p->peHeader.nt.x) \
             << "\n";
 
 int main(int argc, char *argv[]) {
@@ -403,12 +396,11 @@ int main(int argc, char *argv[]) {
     if (GetEntryPoint(p, entryPoint)) {
       std::cout << "First 8 bytes from entry point (0x";
 
-      std::cout << to_string<VA>(entryPoint, std::hex);
-      std::cout << "):" << "\n";
+      std::cout << std::hex << entryPoint << "):" << "\n";
       for (std::size_t i = 0; i < 8; i++) {
         std::uint8_t b;
         ReadByteAtVA(p, i + entryPoint, b);
-        std::cout << " 0x" << to_string<std::uint64_t>(b, std::hex);
+        std::cout << " 0x" << std::hex << static_cast<int>(b);
       }
 
       std::cout << "\n";

--- a/dump-pe/main.cpp
+++ b/dump-pe/main.cpp
@@ -283,8 +283,11 @@ int printTlsWithBinary(void *N, VA funcAddr) {
 
   for (std::size_t i = 0; i < 8; i++) {
     std::uint8_t b;
-    ReadByteAtVA(p, i + address, b);
-    std::cout << " 0x" << std::hex << static_cast<int>(b);
+    if (!ReadByteAtVA(p, i + address, b)) {
+      std::cout << " ERR";
+    } else {
+      std::cout << " 0x" << std::hex << static_cast<int>(b);
+    }
   }
 
   std::cout << "\n";
@@ -399,8 +402,11 @@ int main(int argc, char *argv[]) {
       std::cout << std::hex << entryPoint << "):" << "\n";
       for (std::size_t i = 0; i < 8; i++) {
         std::uint8_t b;
-        ReadByteAtVA(p, i + entryPoint, b);
-        std::cout << " 0x" << std::hex << static_cast<int>(b);
+        if (!ReadByteAtVA(p, i + entryPoint, b)) {
+          std::cout << " ERR";
+        } else {
+          std::cout << " 0x" << std::hex << static_cast<int>(b);
+        }
       }
 
       std::cout << "\n";

--- a/pe-parser-library/include/parser-library/parse.h
+++ b/pe-parser-library/include/parser-library/parse.h
@@ -207,6 +207,10 @@ typedef int (*iterSec)(
     void *, VA secBase, std::string &, image_section_header, bounded_buffer *b);
 void IterSec(parsed_pe *pe, iterSec cb, void *cbd);
 
+// iterate over tls callbacks
+typedef int (*iterTls)(void *, std::uint64_t);
+void IterTls(parsed_pe *pe, iterTls cb, void *cbd);
+
 // get byte at VA in PE
 bool ReadByteAtVA(parsed_pe *pe, VA v, std::uint8_t &b);
 

--- a/pe-parser-library/src/parse.cpp
+++ b/pe-parser-library/src/parse.cpp
@@ -1579,7 +1579,7 @@ bool getTlsCallbacks(parsed_pe *p) {
 
         // The list of TLS callbacks is zero-terminated
         std::uint64_t tlsCallback;
-        do {
+        while (true) {
           if (!readQword(lookupSec.sectionData, lookupOff, tlsCallback)) {
             return false;
           }
@@ -1588,7 +1588,7 @@ bool getTlsCallbacks(parsed_pe *p) {
           }
           tlsData.tlsCallbacks.push_back(tlsCallback);
           lookupOff += 8;
-        } while (true);
+        }
       }
 
     } else {

--- a/pe-parser-library/src/parse.cpp
+++ b/pe-parser-library/src/parse.cpp
@@ -58,6 +58,15 @@ struct reloc {
   reloc_type type;
 };
 
+struct tlsdir {
+  VA dataStartVA;
+  VA dataEndVA;
+  VA indexVA;
+  std::vector<std::uint64_t> tlsCallbacks;
+  std::uint32_t templateSize;
+  std::uint32_t characteristics;
+};
+
 #define SYMBOL_NAME_OFFSET(sn) (static_cast<std::uint32_t>(sn.data >> 32))
 #define SYMBOL_TYPE_HI(x) (x.type >> 8)
 
@@ -119,6 +128,7 @@ struct parsed_pe_internal {
   std::vector<importent> imports;
   std::vector<reloc> relocs;
   std::vector<exportent> exports;
+  std::vector<tlsdir> tls;
   std::vector<symbol> symbols;
 };
 
@@ -356,8 +366,7 @@ bool parse_resource_table(bounded_buffer *sectionData,
           return false;
         }
       }
-    }
-    else {
+    } else {
       /* .rsrc can accomodate up to 2**31 levels, but Windows only uses 3 by convention.
        * As such, any depth above 3 indicates potentially unchecked recusion.
        * See: https://docs.microsoft.com/en-us/windows/desktop/debug/pe-format#the-rsrc-section
@@ -1414,6 +1423,184 @@ bool getImports(parsed_pe *p) {
   return true;
 }
 
+bool getTlsCallbacks(parsed_pe *p) {
+  data_directory tlsDir;
+  if (p->peHeader.nt.OptionalMagic == NT_OPTIONAL_32_MAGIC) {
+    tlsDir = p->peHeader.nt.OptionalHeader.DataDirectory[DIR_TLS];
+  } else if (p->peHeader.nt.OptionalMagic == NT_OPTIONAL_64_MAGIC) {
+    tlsDir = p->peHeader.nt.OptionalHeader64.DataDirectory[DIR_TLS];
+  } else {
+    return false;
+  }
+
+  if (tlsDir.Size != 0) {
+    section s;
+    VA addr;
+    if (p->peHeader.nt.OptionalMagic == NT_OPTIONAL_32_MAGIC) {
+      addr = tlsDir.VirtualAddress + p->peHeader.nt.OptionalHeader.ImageBase;
+    } else if (p->peHeader.nt.OptionalMagic == NT_OPTIONAL_64_MAGIC) {
+      addr =
+          tlsDir.VirtualAddress + p->peHeader.nt.OptionalHeader64.ImageBase;
+    } else {
+      return false;
+    }
+
+    if (!getSecForVA(p->internal->secs, addr, s)) {
+      return false;
+    }
+
+    // Get tls directory from this section
+    auto rvaofft = static_cast<std::uint32_t>(addr - s.sectionBase);
+
+    std::uint64_t imageBase = 0;
+    if (p->peHeader.nt.OptionalMagic == NT_OPTIONAL_32_MAGIC) {
+      imageBase = p->peHeader.nt.OptionalHeader.ImageBase;
+    } else if (p->peHeader.nt.OptionalMagic == NT_OPTIONAL_64_MAGIC) {
+      imageBase = p->peHeader.nt.OptionalHeader64.ImageBase;
+    } else {
+      return false;
+    }
+
+    // Reference:
+    //   https://docs.microsoft.com/en-us/windows/desktop/Debug/pe-format#the-tls-directory
+    tlsdir tlsData;
+
+    if (p->peHeader.nt.OptionalMagic == NT_OPTIONAL_32_MAGIC) {
+      std::uint32_t val32;
+
+      // Get the start and end of the initialized data template
+      if (!readDword(s.sectionData, rvaofft, val32)) {
+        return false;
+      } else {
+        tlsData.dataStartVA = val32 + imageBase;
+      }
+      if (!readDword(s.sectionData, rvaofft + 4, val32)) {
+        return false;
+      } else {
+        tlsData.dataEndVA = val32 + imageBase;
+      }
+
+      // Get the location to receive the TLS index
+      if (!readDword(s.sectionData, rvaofft + 8, val32)) {
+        return false;
+      } else {
+        tlsData.indexVA = val32 + imageBase;
+      }
+
+      // Get the address to the array of TLS callbacks
+      std::uint32_t addrOfCallbacks;
+      if (!readDword(s.sectionData, rvaofft + 12, addrOfCallbacks)) {
+        return false;
+      }
+
+      // Get the total size of the data template
+      if (!readDword(s.sectionData, rvaofft + 16, tlsData.templateSize)) {
+        return false;
+      }
+
+      // Get the memory characteristics of the data template
+      if (!readDword(s.sectionData, rvaofft + 20, tlsData.characteristics)) {
+        return false;
+      }
+
+      // Build the list of TLS callbacks
+      if (addrOfCallbacks != 0) {
+        // Calculate the section and offset to the start of the TLS callbacks
+        section lookupSec;
+        if (!getSecForVA(p->internal->secs, addrOfCallbacks, lookupSec)) {
+          return false;
+        }
+
+        auto lookupOff =
+            static_cast<std::uint32_t>(addrOfCallbacks - lookupSec.sectionBase);
+
+        // The list of TLS callbacks is zero-terminated
+        std::uint32_t tlsCallback;
+        do {
+          if (!readDword(lookupSec.sectionData, lookupOff, tlsCallback)) {
+            return false;
+          }
+          if (tlsCallback == 0) {
+            break;
+          }
+          tlsData.tlsCallbacks.push_back(tlsCallback);
+          lookupOff += 4;
+        } while (true);
+      }
+
+    } else if (p->peHeader.nt.OptionalMagic == NT_OPTIONAL_64_MAGIC) {
+      std::uint64_t val64;
+
+      // Get the start and end of the initialized data template
+      if (!readQword(s.sectionData, rvaofft, val64)) {
+        return false;
+      } else {
+        tlsData.dataStartVA = val64 + imageBase;
+      }
+      if (!readQword(s.sectionData, rvaofft + 8, val64)) {
+        return false;
+      } else {
+        tlsData.dataEndVA = val64 + imageBase;
+      }
+
+      // Get the location to receive the TLS index
+      if (!readQword(s.sectionData, rvaofft + 16, val64)) {
+        return false;
+      } else {
+        tlsData.indexVA = val64 + imageBase;
+      }
+
+      // Get the address to the array of TLS callbacks
+      std::uint64_t addrOfCallbacks;
+      if (!readQword(s.sectionData, rvaofft + 24, addrOfCallbacks)) {
+        return false;
+      }
+
+      // Get the total size of the data template
+      if (!readDword(s.sectionData, rvaofft + 32, tlsData.templateSize)) {
+        return false;
+      }
+
+      // Get the memory characteristics of the data template
+      if (!readDword(s.sectionData, rvaofft + 36, tlsData.characteristics)) {
+        return false;
+      }
+
+      // Build the list of TLS callbacks
+      if (addrOfCallbacks != 0) {
+        // Calculate the section and offset to the start of the TLS callbacks
+        section lookupSec;
+        if (!getSecForVA(p->internal->secs, addrOfCallbacks, lookupSec)) {
+          return false;
+        }
+
+        auto lookupOff =
+            static_cast<std::uint32_t>(addrOfCallbacks - lookupSec.sectionBase);
+
+        // The list of TLS callbacks is zero-terminated
+        std::uint64_t tlsCallback;
+        do {
+          if (!readQword(lookupSec.sectionData, lookupOff, tlsCallback)) {
+            return false;
+          }
+          if (tlsCallback == 0) {
+            break;
+          }
+          tlsData.tlsCallbacks.push_back(tlsCallback);
+          lookupOff += 8;
+        } while (true);
+      }
+
+    } else {
+      return false;
+    }
+
+    p->internal->tls.push_back(tlsData);
+  }
+
+  return true;
+}
+
 bool getSymbolTable(parsed_pe *p) {
   if (p->peHeader.nt.FileHeader.PointerToSymbolTable == 0) {
     return true;
@@ -1826,6 +2013,14 @@ parsed_pe *ParsePEFromFile(const char *filePath) {
     return nullptr;
   }
 
+  // Get tls
+  if (!getTlsCallbacks(p)) {
+    deleteBuffer(remaining);
+    deleteBuffer(p->fileBuffer);
+    delete p;
+    return nullptr;
+  }
+
   // Get symbol table
   if (!getSymbolTable(p)) {
     deleteBuffer(remaining);
@@ -1926,6 +2121,21 @@ void IterSec(parsed_pe *pe, iterSec cb, void *cbd) {
 
   for (section s : pint->secs) {
     if (cb(cbd, s.sectionBase, s.sectionName, s.sec, s.sectionData) != 0) {
+      break;
+    }
+  }
+
+  return;
+}
+
+// iterate over tls callbacks
+void IterTls(parsed_pe *pe, iterTls cb, void *cbd) {
+  parsed_pe_internal *pint = pe->internal;
+  if (pint->tls.empty()) return;
+
+  tlsdir t = pint->tls.front();
+  for (std::uint64_t c : t.tlsCallbacks) {
+    if (cb(cbd, c) != 0) {
       break;
     }
   }

--- a/python/pepy.cpp
+++ b/python/pepy.cpp
@@ -366,8 +366,9 @@ pepy_tls_callback_new(PyTypeObject *type, PyObject *args, PyObject *kwds) {
 
 static int pepy_tls_callback_init(pepy_tls_callback *self, PyObject *args, PyObject *kwds) {
   if (!PyArg_ParseTuple(
-          args, "O:pepy_tls_callback_init", &self->addr))
+          args, "O:pepy_tls_callback_init", &self->addr)) {
     return -1;
+  }
   return 0;
 }
 

--- a/python/pepy.cpp
+++ b/python/pepy.cpp
@@ -1162,7 +1162,7 @@ int tls_callback(void *cbd, VA addr) {
   PyObject *tlscb;
   PyObject *list = (PyObject *) cbd;
 
-  tlscb = PyLong_FromUnsignedLong(addr);
+  tlscb = PyLong_FromUnsignedLongLong(addr);
   if (!tlscb) {
     PyErr_SetString(pepy_error, "Error getting tls callback.");
     return 1;
@@ -1219,13 +1219,13 @@ PEPY_PARSED_GET(magic, OptionalMagic)
     PyObject *ret = NULL;                                                  \
     if (((pepy_parsed *) self)->pe->peHeader.nt.OptionalMagic ==           \
         NT_OPTIONAL_32_MAGIC) {                                            \
-      ret = PyLong_FromUnsignedLong(                                       \
+      ret = PyLong_FromUnsignedLongLong(                                       \
           ((pepy_parsed *) self)->pe->peHeader.nt.OptionalHeader.VAL);     \
       if (!ret)                                                            \
         PyErr_SetString(PyExc_AttributeError, "Error getting attribute."); \
     } else if (((pepy_parsed *) self)->pe->peHeader.nt.OptionalMagic ==    \
                NT_OPTIONAL_64_MAGIC) {                                     \
-      ret = PyLong_FromUnsignedLong(                                       \
+      ret = PyLong_FromUnsignedLongLong(                                       \
           ((pepy_parsed *) self)->pe->peHeader.nt.OptionalHeader64.VAL);   \
       if (!ret)                                                            \
         PyErr_SetString(PyExc_AttributeError, "Error getting attribute."); \

--- a/python/pepy.cpp
+++ b/python/pepy.cpp
@@ -1219,13 +1219,13 @@ PEPY_PARSED_GET(magic, OptionalMagic)
     PyObject *ret = NULL;                                                  \
     if (((pepy_parsed *) self)->pe->peHeader.nt.OptionalMagic ==           \
         NT_OPTIONAL_32_MAGIC) {                                            \
-      ret = PyLong_FromUnsignedLongLong(                                       \
+      ret = PyLong_FromUnsignedLongLong(                                   \
           ((pepy_parsed *) self)->pe->peHeader.nt.OptionalHeader.VAL);     \
       if (!ret)                                                            \
         PyErr_SetString(PyExc_AttributeError, "Error getting attribute."); \
     } else if (((pepy_parsed *) self)->pe->peHeader.nt.OptionalMagic ==    \
                NT_OPTIONAL_64_MAGIC) {                                     \
-      ret = PyLong_FromUnsignedLongLong(                                       \
+      ret = PyLong_FromUnsignedLongLong(                                   \
           ((pepy_parsed *) self)->pe->peHeader.nt.OptionalHeader64.VAL);   \
       if (!ret)                                                            \
         PyErr_SetString(PyExc_AttributeError, "Error getting attribute."); \

--- a/python/pepy.cpp
+++ b/python/pepy.cpp
@@ -124,6 +124,10 @@ struct pepy_relocation {
   PyObject *addr;
 };
 
+struct pepy_tls_callback {
+  PyObject_HEAD PyObject *addr;
+};
+
 /* None of the attributes in these objects are writable. */
 static int
 pepy_attr_not_writable(PyObject *self, PyObject *value, void *closure) {
@@ -349,6 +353,73 @@ static PyTypeObject pepy_relocation_type = {
     (initproc) pepy_relocation_init,      /* tp_init */
     0,                                    /* tp_alloc */
     pepy_relocation_new                   /* tp_new */
+};
+
+static PyObject *
+pepy_tls_callback_new(PyTypeObject *type, PyObject *args, PyObject *kwds) {
+  pepy_tls_callback *self;
+
+  self = (pepy_tls_callback *) type->tp_alloc(type, 0);
+
+  return (PyObject *) self;
+}
+
+static int pepy_tls_callback_init(pepy_tls_callback *self, PyObject *args, PyObject *kwds) {
+  if (!PyArg_ParseTuple(
+          args, "O:pepy_tls_callback_init", &self->addr))
+    return -1;
+  return 0;
+}
+
+static void pepy_tls_callback_dealloc(pepy_tls_callback *self) {
+  Py_TYPE(self)->tp_free((PyObject *) self);
+}
+
+PEPY_OBJECT_GET(tls_callback, addr)
+
+static PyGetSetDef pepy_tls_callback_getseters[] = {
+    OBJECTGETTER(tls_callback, addr, "Address"),
+    {NULL}};
+
+static PyTypeObject pepy_tls_callback_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)    /* ob_size */
+    "pepy.tls_callback",              /* tp_name */
+    sizeof(pepy_tls_callback),        /* tp_basicsize */
+    0,                                /* tp_itemsize */
+    (destructor) pepy_tls_callback_dealloc, /* tp_dealloc */
+    0,                                /* tp_print */
+    0,                                /* tp_getattr */
+    0,                                /* tp_setattr */
+    0,                                /* tp_compare */
+    0,                                /* tp_repr */
+    0,                                /* tp_as_number */
+    0,                                /* tp_as_sequence */
+    0,                                /* tp_as_mapping */
+    0,                                /* tp_hash */
+    0,                                /* tp_call */
+    0,                                /* tp_str */
+    0,                                /* tp_getattro */
+    0,                                /* tp_setattro */
+    0,                                /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT,               /* tp_flags */
+    "pepy tls callback object",       /* tp_doc */
+    0,                                /* tp_traverse */
+    0,                                /* tp_clear */
+    0,                                /* tp_richcompare */
+    0,                                /* tp_weaklistoffset */
+    0,                                /* tp_iter */
+    0,                                /* tp_iternext */
+    0,                                /* tp_methods */
+    0,                                /* tp_members */
+    pepy_tls_callback_getseters,      /* tp_getset */
+    0,                                /* tp_base */
+    0,                                /* tp_dict */
+    0,                                /* tp_descr_get */
+    0,                                /* tp_descr_set */
+    0,                                /* tp_dictoffset */
+    (initproc) pepy_tls_callback_init, /* tp_init */
+    0,                                /* tp_alloc */
+    pepy_tls_callback_new             /* tp_new */
 };
 
 static PyObject *
@@ -1087,6 +1158,36 @@ static PyObject *pepy_parsed_get_relocations(PyObject *self, PyObject *args) {
   return ret;
 }
 
+int tls_callback(void *cbd, VA addr) {
+  PyObject *tlscb;
+  PyObject *list = (PyObject *) cbd;
+
+  tlscb = PyLong_FromUnsignedLong(addr);
+  if (!tlscb) {
+    PyErr_SetString(pepy_error, "Error getting tls callback.");
+    return 1;
+  }
+
+  if (PyList_Append(list, tlscb) == -1) {
+    Py_DECREF(tlscb);
+    return 1;
+  }
+
+  return 0;
+}
+
+static PyObject *pepy_parsed_get_tls_callbacks(PyObject *self, PyObject *args) {
+  PyObject *ret = PyList_New(0);
+  if (!ret) {
+    PyErr_SetString(pepy_error, "Unable to create new list.");
+    return NULL;
+  }
+
+  IterTls(((pepy_parsed *) self)->pe, tls_callback, ret);
+
+  return ret;
+}
+
 #define PEPY_PARSED_GET(ATTR, VAL)                                         \
   static PyObject *pepy_parsed_get_##ATTR(PyObject *self, void *closure) { \
     PyObject *ret =                                                        \
@@ -1118,13 +1219,13 @@ PEPY_PARSED_GET(magic, OptionalMagic)
     PyObject *ret = NULL;                                                  \
     if (((pepy_parsed *) self)->pe->peHeader.nt.OptionalMagic ==           \
         NT_OPTIONAL_32_MAGIC) {                                            \
-      ret = PyLong_FromUnsignedLongLong(                                   \
+      ret = PyLong_FromUnsignedLong(                                       \
           ((pepy_parsed *) self)->pe->peHeader.nt.OptionalHeader.VAL);     \
       if (!ret)                                                            \
         PyErr_SetString(PyExc_AttributeError, "Error getting attribute."); \
     } else if (((pepy_parsed *) self)->pe->peHeader.nt.OptionalMagic ==    \
                NT_OPTIONAL_64_MAGIC) {                                     \
-      ret = PyLong_FromUnsignedLongLong(                                   \
+      ret = PyLong_FromUnsignedLong(                                       \
           ((pepy_parsed *) self)->pe->peHeader.nt.OptionalHeader64.VAL);   \
       if (!ret)                                                            \
         PyErr_SetString(PyExc_AttributeError, "Error getting attribute."); \
@@ -1254,6 +1355,10 @@ static PyMethodDef pepy_parsed_methods[] = {
      pepy_parsed_get_relocations,
      METH_NOARGS,
      "Return a list of relocation objects."},
+    {"get_tls_callbacks",
+     pepy_parsed_get_tls_callbacks,
+     METH_NOARGS,
+     "Return a list of VAs that are TLS callbacks."},
     {"get_resources",
      pepy_parsed_get_resources,
      METH_NOARGS,
@@ -1345,6 +1450,7 @@ static PyObject *pepi_module_init(void) {
       PyType_Ready(&pepy_import_type) < 0 ||
       PyType_Ready(&pepy_export_type) < 0 ||
       PyType_Ready(&pepy_relocation_type) < 0 ||
+      PyType_Ready(&pepy_tls_callback_type) < 0 ||
       PyType_Ready(&pepy_resource_type) < 0)
     return NULL;
 
@@ -1388,6 +1494,9 @@ static PyObject *pepi_module_init(void) {
 
   Py_INCREF(&pepy_relocation_type);
   PyModule_AddObject(m, "pepy_relocation", (PyObject *) &pepy_relocation_type);
+
+  Py_INCREF(&pepy_tls_callback_type);
+  PyModule_AddObject(m, "pepy_tls_callback", (PyObject *) &pepy_tls_callback_type);
 
   Py_INCREF(&pepy_resource_type);
   PyModule_AddObject(m, "pepy_resource", (PyObject *) &pepy_resource_type);


### PR DESCRIPTION
* Parse the TLS data directory of the PE header
* Expose TLS callbacks to pepy
* Update dump-pe to use uint64_t for fields with values greater than UINT32_MAX