### PR TITLE
Fix 'type qualifiers ignored on cast result type' warning

### DIFF
--- a/pe-parser-library/include/parser-library/nt-headers.h
+++ b/pe-parser-library/include/parser-library/nt-headers.h
@@ -193,7 +193,7 @@ constexpr std::uint16_t IMAGE_SYM_DTYPE_FUNCTION = 2;
 constexpr std::uint16_t IMAGE_SYM_DTYPE_ARRAY = 3;
 
 // Symbol table storage classes
-constexpr std::uint8_t IMAGE_SYM_CLASS_END_OF_FUNCTION = static_cast<const std::uint8_t>(-1);
+constexpr std::uint8_t IMAGE_SYM_CLASS_END_OF_FUNCTION = static_cast<std::uint8_t>(-1);
 constexpr std::uint8_t IMAGE_SYM_CLASS_NULL = 0;
 constexpr std::uint8_t IMAGE_SYM_CLASS_AUTOMATIC = 1;
 constexpr std::uint8_t IMAGE_SYM_CLASS_EXTERNAL = 2;


### PR DESCRIPTION
Fixes this warning preventing compilation:

```
cd /home/redfast00/tools/pe-parse/build/pe-parser-library && /usr/bin/c++   -I/home/redfast00/tools/pe-parse/pe-parser-library/include  -O3 -DNDEBUG   -fPIC -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization -Wformat=2 -Winit-self -Wlong-long -Wmissing-declarations -Wmissing-include-dirs -Wcomment -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wsign-conversion -Wsign-promo -Wstrict-overflow=5 -Wswitch-default -Wundef -Werror -Wunused -Wuninitialized -Wno-missing-declarations -Wno-strict-overflow -std=c++11 -o CMakeFiles/pe-parser-library.dir/src/buffer.cpp.o -c /home/redfast00/tools/pe-parse/pe-parser-library/src/buffer.cpp
In file included from /home/redfast00/tools/pe-parse/pe-parser-library/include/parser-library/parse.h:30,
                 from /home/redfast00/tools/pe-parse/pe-parser-library/src/buffer.cpp:29:
/home/redfast00/tools/pe-parse/pe-parser-library/include/parser-library/nt-headers.h:196:92: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
  196 | constexpr std::uint8_t IMAGE_SYM_CLASS_END_OF_FUNCTION = static_cast<const std::uint8_t>(-1);
      |                                                                                            ^
cc1plus: all warnings being treated as errors

```