### PR TITLE
pe-parser-library, dump-pe: Windows.h accommodations

### DIFF
--- a/dump-pe/main.cpp
+++ b/dump-pe/main.cpp
@@ -64,28 +64,28 @@ int printRelocs(void *N, VA relocAddr, reloc_type type) {
 
   std::cout << "TYPE: ";
   switch (type) {
-    case ABSOLUTE:
+    case RELOC_ABSOLUTE:
       std::cout << "ABSOLUTE";
       break;
-    case HIGH:
+    case RELOC_HIGH:
       std::cout << "HIGH";
       break;
-    case LOW:
+    case RELOC_LOW:
       std::cout << "LOW";
       break;
-    case HIGHLOW:
+    case RELOC_HIGHLOW:
       std::cout << "HIGHLOW";
       break;
-    case HIGHADJ:
+    case RELOC_HIGHADJ:
       std::cout << "HIGHADJ";
       break;
-    case MIPS_JMPADDR:
+    case RELOC_MIPS_JMPADDR:
       std::cout << "MIPS_JMPADDR";
       break;
-    case MIPS_JMPADDR16:
+    case RELOC_MIPS_JMPADDR16:
       std::cout << "MIPS_JMPADD16";
       break;
-    case DIR64:
+    case RELOC_DIR64:
       std::cout << "DIR64";
       break;
     default:

--- a/pe-parser-library/include/parser-library/nt-headers.h
+++ b/pe-parser-library/include/parser-library/nt-headers.h
@@ -48,6 +48,7 @@ constexpr std::uint16_t NT_OPTIONAL_64_MAGIC = 0x20B;
 constexpr std::uint16_t NT_SHORT_NAME_LEN = 8;
 constexpr std::uint16_t SYMTAB_RECORD_LEN = 18;
 
+#ifndef _PEPARSE_WINDOWS_CONFLICTS
 // Machine Types
 constexpr std::uint16_t IMAGE_FILE_MACHINE_UNKNOWN = 0x0;
 constexpr std::uint16_t IMAGE_FILE_MACHINE_ALPHA = 0x1d3;     // Alpha_AXP
@@ -209,6 +210,7 @@ constexpr std::uint8_t IMAGE_SYM_CLASS_FILE = 103;
 constexpr std::uint8_t IMAGE_SYM_CLASS_SECTION = 104;
 constexpr std::uint8_t IMAGE_SYM_CLASS_WEAK_EXTERNAL = 105;
 constexpr std::uint8_t IMAGE_SYM_CLASS_CLR_TOKEN = 107;
+#endif
 // clang-format on
 
 struct dos_header {
@@ -440,15 +442,15 @@ struct export_dir_table {
 };
 
 enum reloc_type {
-  ABSOLUTE = 0,
-  HIGH = 1,
-  LOW = 2,
-  HIGHLOW = 3,
-  HIGHADJ = 4,
-  MIPS_JMPADDR = 5,
-  MIPS_JMPADDR16 = 9,
-  IA64_IMM64 = 9,
-  DIR64 = 10
+  RELOC_ABSOLUTE = 0,
+  RELOC_HIGH = 1,
+  RELOC_LOW = 2,
+  RELOC_HIGHLOW = 3,
+  RELOC_HIGHADJ = 4,
+  RELOC_MIPS_JMPADDR = 5,
+  RELOC_MIPS_JMPADDR16 = 9,
+  RELOC_IA64_IMM64 = 9,
+  RELOC_DIR64 = 10
 };
 
 struct reloc_block {

--- a/pe-parser-library/include/parser-library/parse.h
+++ b/pe-parser-library/include/parser-library/parse.h
@@ -99,6 +99,7 @@ struct resource {
   bounded_buffer *buf;
 };
 
+#ifndef _PEPARSE_WINDOWS_CONFLICTS
 // http://msdn.microsoft.com/en-us/library/ms648009(v=vs.85).aspx
 enum resource_type {
   RT_CURSOR = 1,
@@ -123,6 +124,7 @@ enum resource_type {
   RT_HTML = 23,
   RT_MANIFEST = 24
 };
+#endif
 
 enum pe_err {
   PEERR_NONE = 0,


### PR DESCRIPTION
Introduces a preprocessor check for `_PEPARSE_WINDOWS_CONFLICTS`, which causes some constants and enums to not be defined. This makes it easier to use pe-parse in a translation unit where `Windows.h` is also included, since `Windows.h` provides identical values in macro form.

`_PEPARSE_WINDOWS_CONFLICTS` is *intentionally* not synonymous with `_WIN32` or other Windows feature tests, since users *may* want to use the definitions provided by pe-parse in a context where `Windows.h` is not included.

Closes #98.