### PR TITLE
Fix PEPARSE_INCLUDE_DIR for cross-compiling

### DIFF
--- a/pe-parser-library/cmake/peparse-config.cmake
+++ b/pe-parser-library/cmake/peparse-config.cmake
@@ -1,4 +1,8 @@
-find_path(PEPARSE_INCLUDE_DIR $<SHELL_PATH:"parser-library/parse.h">)
+if(CMAKE_CROSSCOMPILING)
+  find_path(PEPARSE_INCLUDE_DIR "parser-library/parse.h")
+else()
+  find_path(PEPARSE_INCLUDE_DIR $<SHELL_PATH:"parser-library/parse.h">)
+endif()
 find_library(PEPARSE_LIBRARIES NAMES "libpe-parser-library" "pe-parser-library")
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
Commit https://github.com/trailofbits/pe-parse/commit/a8f7da7a2b0c71e48c6cc41446d878527254af3e breaks cross-compiling for windows from Linux for me.
