### PR TITLE
Compile pepy with unicode_codecvt

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -32,7 +32,8 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 SOURCE_FILES = [os.path.join(here, 'pepy.cpp'),
                 os.path.abspath(os.path.join(here, '..', 'pe-parser-library', 'src', 'parse.cpp')),
-                os.path.abspath(os.path.join(here, '..', 'pe-parser-library', 'src', 'buffer.cpp'))]
+                os.path.abspath(os.path.join(here, '..', 'pe-parser-library', 'src', 'buffer.cpp')),
+                os.path.abspath(os.path.join(here, '..', 'pe-parser-library', 'src', 'unicode_codecvt.cpp'))]
 
 if platform.system() == 'Windows':
   INCLUDE_DIRS = [os.path.abspath(os.path.join(os.path.dirname(sys.executable), 'include')),


### PR DESCRIPTION
Ideally, we would be able to autodetect which unicode library we want to
use, but this should hopefully work as a stop-gap solution.

FYI: This issue was found by trying to run the python test scripts on the executable from here https://www.calculator.org/download.html (specifically this URL https://www.calculator.org/fsi/c9853w.exe), which gave me an error with undefined symbol for (demangled) 
```
peparse::from_utf16(std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > const&)
```