### PR TITLE
parse: Handle a potential nullptr from splitBuffer

### DIFF
--- a/pe-parser-library/src/parse.cpp
+++ b/pe-parser-library/src/parse.cpp
@@ -937,6 +937,14 @@ bool getSections(bounded_buffer *b,
     std::uint32_t highOff = lowOff + curSec.SizeOfRawData;
     thisSec.sectionData = splitBuffer(fileBegin, lowOff, highOff);
 
+    // GH#109: we trusted [lowOff, highOff) to be a range that yields
+    // a valid bounded_buffer, despite these being user-controllable.
+    // splitBuffer correctly handles this, but we failed to check for
+    // the nullptr it returns as a sentinel.
+    if (thisSec.sectionData == nullptr) {
+      return false;
+    }
+
     secs.push_back(thisSec);
   }
 


### PR DESCRIPTION
Identified by #109: when parsing the PE sections, we incorrectly
trust that the offset range given to us by each section is valid.

We pass this range to splitBuffer expectly a valid bounded_buffer.

splitBuffer correctly determines that the range is invalid, and
returns a nullptr to indicate failure.

We fail to check for that nullptr in getSections, resulting in
an eventual segfault by null dereference when we attempt to
reference the invalid section.

This commit adds a check for that nullptr and causes getSections
to return false. This is then propagated as an invalid
section error.

Example:

```bash
/app/pe-parse # /usr/bin/dump-pe /tmp/test1.exe
Error: 3 (Invalid section)
Location: ParsePEFromFile:2380
```

Fixes #109.