### PR TITLE
Dockerfile, cmake: Simplify build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,15 @@ LABEL creator "Trail of Bits"
 LABEL dockerfile_maintenance "William Woodruff <william@trailofbits>"
 LABEL desc "Principled, lightweight C/C++ PE parser"
 
-RUN apk add --no-cache cmake icu-dev build-base
+RUN apk add --no-cache cmake icu-dev clang build-base
 
 COPY . /app/pe-parse
 WORKDIR /app/pe-parse
 RUN mkdir build && \
     cd build && \
     cmake -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" .. && \
-    cmake --build . --config "${BUILD_TYPE}" && \
-    cmake --build . --config "${BUILD_TYPE}" --target install
+    cmake --build . && \
+    cmake --build . --target install
 
 ENTRYPOINT [ "/usr/bin/dump-pe" ]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apk add --no-cache cmake icu-dev clang build-base
 
 COPY . /app/pe-parse
 WORKDIR /app/pe-parse
+ENV CC=clang CXX=clang++
 RUN mkdir build && \
     cd build && \
     cmake -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" .. && \

--- a/cmake/compilation_flags.cmake
+++ b/cmake/compilation_flags.cmake
@@ -32,10 +32,8 @@ else ()
   endif ()
 
   if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    message(STATUS "This is a debug build; enabling -Weverything...")
-
     list(APPEND DEFAULT_CXX_FLAGS
-      -Weverything -Wno-c++98-compat -Wno-missing-prototypes
+      -Wno-c++98-compat -Wno-missing-prototypes
       -Wno-missing-variable-declarations -Wno-global-constructors
       -Wno-exit-time-destructors -Wno-padded -Wno-error
     )

--- a/python/setup.py
+++ b/python/setup.py
@@ -10,7 +10,7 @@
 # 2. Redistributions in binary form must reproduce the above copyright
 #    notice, this list of conditions and the following disclaimer in the
 #    documentation and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -30,40 +30,53 @@ import platform
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-SOURCE_FILES = [os.path.join(here, 'pepy.cpp'),
-                os.path.abspath(os.path.join(here, '..', 'pe-parser-library', 'src', 'parse.cpp')),
-                os.path.abspath(os.path.join(here, '..', 'pe-parser-library', 'src', 'buffer.cpp')),
-                os.path.abspath(os.path.join(here, '..', 'pe-parser-library', 'src', 'unicode_codecvt.cpp'))]
+SOURCE_FILES = [
+    os.path.join(here, "pepy.cpp"),
+    os.path.abspath(os.path.join(here, "..", "pe-parser-library", "src", "parse.cpp")),
+    os.path.abspath(os.path.join(here, "..", "pe-parser-library", "src", "buffer.cpp")),
+    os.path.abspath(
+        os.path.join(here, "..", "pe-parser-library", "src", "unicode_codecvt.cpp")
+    ),
+]
 
-if platform.system() == 'Windows':
-  INCLUDE_DIRS = [os.path.abspath(os.path.join(os.path.dirname(sys.executable), 'include')),
-                  os.path.abspath(os.path.join(here, '..', 'pe-parser-library', 'include')),
-                  'C:\\usr\\include']
-  LIBRARY_DIRS = [os.path.abspath(os.path.join(os.path.dirname(sys.executable), 'libs')),
-                  'C:\\usr\\lib']
-  COMPILE_ARGS = ["/EHsc"]
+if platform.system() == "Windows":
+    INCLUDE_DIRS = [
+        os.path.abspath(os.path.join(os.path.dirname(sys.executable), "include")),
+        os.path.abspath(os.path.join(here, "..", "pe-parser-library", "include")),
+        "C:\\usr\\include",
+    ]
+    LIBRARY_DIRS = [
+        os.path.abspath(os.path.join(os.path.dirname(sys.executable), "libs")),
+        "C:\\usr\\lib",
+    ]
+    COMPILE_ARGS = ["/EHsc"]
 else:
-  INCLUDE_DIRS = ['/usr/local/include',
-                  '/opt/local/include',
-                  '/usr/include',
-                  os.path.abspath(os.path.join(here, '..', 'pe-parser-library', 'include'))]
-  LIBRARY_DIRS = ['/usr/lib',
-                  '/usr/local/lib']
-  COMPILE_ARGS = ["-std=c++11", "-g", "-O0"] # Debug only
+    INCLUDE_DIRS = [
+        "/usr/local/include",
+        "/opt/local/include",
+        "/usr/include",
+        os.path.abspath(os.path.join(here, "..", "pe-parser-library", "include")),
+    ]
+    LIBRARY_DIRS = ["/usr/lib", "/usr/local/lib"]
+    COMPILE_ARGS = ["-std=c++11", "-g", "-O0"]  # Debug only
 
-extension_mod = Extension('pepy',
-                          sources = SOURCE_FILES,
-                          extra_compile_args = COMPILE_ARGS,
-                          language='c++',
-                          include_dirs = INCLUDE_DIRS,
-                          library_dirs = LIBRARY_DIRS)
+extension_mod = Extension(
+    "pepy",
+    sources=SOURCE_FILES,
+    extra_compile_args=COMPILE_ARGS,
+    language="c++",
+    include_dirs=INCLUDE_DIRS,
+    library_dirs=LIBRARY_DIRS,
+)
 
 
-setup (name = 'pepy',
-       version = '0.1',
-       description = 'python bindings for pe-parse',
-       author = 'Wesley Shields',
-       author_email = 'wxs@atarininja.org',
-       license = 'BSD',
-       long_description = 'Python bindings for pe-parse',
-       ext_modules = [extension_mod])
+setup(
+    name="pepy",
+    version="0.1",
+    description="python bindings for pe-parse",
+    author="Wesley Shields",
+    author_email="wxs@atarininja.org",
+    license="BSD",
+    long_description="Python bindings for pe-parse",
+    ext_modules=[extension_mod],
+)


### PR DESCRIPTION
Always use clang in the Dockerfile, and don't overspecify
the build type.

Additionally, drop -Weverything when building in Debug mode --
it has competing flags internally and isn't intended for actual
builds.