### PR TITLE
CMake: Set minimum to 3.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
 project(pe-parse)
 
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/dump-pe/CMakeLists.txt
+++ b/dump-pe/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
 project(dump-pe)
 
 add_executable(${PROJECT_NAME} main.cpp)

--- a/examples/peaddrconv/CMakeLists.txt
+++ b/examples/peaddrconv/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
 project(peaddrconv)
 
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/pe-parser-library/CMakeLists.txt
+++ b/pe-parser-library/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
 project(pe-parser-library)
 
 message(STATUS "VERSION file: ${CMAKE_SOURCE_DIR}/VERSION")


### PR DESCRIPTION
This was incorrectly set to 3.7, despite add_compile_definitions appearing in 3.11.