### PR TITLE
parse: Fix small memory leak

### DIFF
--- a/pe-parser-library/src/parse.cpp
+++ b/pe-parser-library/src/parse.cpp
@@ -2670,6 +2670,7 @@ bool GetDataDirectoryEntry(parsed_pe *pe,
     }
 
     raw_entry.assign(buf->buf, buf->buf + buf->bufLen);
+    deleteBuffer(buf);
   } else {
     section sec;
     if (!getSecForVA(pe->internal->secs, addr, sec)) {


### PR DESCRIPTION
Getting the `DIR_SECURITY` entry requires a `splitBuffer` call, which was never freed. This would leak a couple dozen bytes.