### PR TITLE
Fix undefined behavior

### DIFF
--- a/pe-parser-library/src/buffer.cpp
+++ b/pe-parser-library/src/buffer.cpp
@@ -112,11 +112,12 @@ bool readWord(bounded_buffer *b, std::uint32_t offset, std::uint16_t &out) {
     return false;
   }
 
-  std::uint16_t *tmp = reinterpret_cast<std::uint16_t *>(b->buf + offset);
+  std::uint16_t tmp;
+  memcpy(&tmp, (b->buf + offset), sizeof(std::uint16_t));
   if (b->swapBytes) {
-    out = byteSwapUint16(*tmp);
+    out = byteSwapUint16(tmp);
   } else {
-    out = *tmp;
+    out = tmp;
   }
 
   return true;
@@ -133,11 +134,12 @@ bool readDword(bounded_buffer *b, std::uint32_t offset, std::uint32_t &out) {
     return false;
   }
 
-  std::uint32_t *tmp = reinterpret_cast<std::uint32_t *>(b->buf + offset);
+  std::uint32_t tmp;
+  memcpy(&tmp, (b->buf + offset), sizeof(std::uint32_t));
   if (b->swapBytes) {
-    out = byteSwapUint32(*tmp);
+    out = byteSwapUint32(tmp);
   } else {
-    out = *tmp;
+    out = tmp;
   }
 
   return true;
@@ -154,11 +156,12 @@ bool readQword(bounded_buffer *b, std::uint32_t offset, std::uint64_t &out) {
     return false;
   }
 
-  std::uint64_t *tmp = reinterpret_cast<std::uint64_t *>(b->buf + offset);
+  std::uint64_t tmp;
+  memcpy(&tmp, (b->buf + offset), sizeof(std::uint64_t));
   if (b->swapBytes) {
-    out = byteSwapUint64(*tmp);
+    out = byteSwapUint64(tmp);
   } else {
-    out = *tmp;
+    out = tmp;
   }
 
   return true;

--- a/pe-parser-library/src/buffer.cpp
+++ b/pe-parser-library/src/buffer.cpp
@@ -178,16 +178,16 @@ bool readChar16(bounded_buffer *b, std::uint32_t offset, char16_t &out) {
     return false;
   }
 
-  char16_t *tmp = nullptr;
+  char16_t tmp;
   if (b->swapBytes) {
     std::uint8_t tmpBuf[2];
     tmpBuf[0] = *(b->buf + offset + 1);
     tmpBuf[1] = *(b->buf + offset);
-    tmp = reinterpret_cast<char16_t *>(tmpBuf);
+    memcpy(&tmp, tmpBuf, sizeof(std::uint16_t));
   } else {
-    tmp = reinterpret_cast<char16_t *>(b->buf + offset);
+    memcpy(&tmp, (b->buf + offset), sizeof(std::uint16_t));
   }
-  out = *tmp;
+  out = tmp;
 
   return true;
 }


### PR DESCRIPTION
Caught with UBSAN with error messages like
```
../pe-parser-library/src/buffer.cpp:140:11: runtime error: load of misaligned address 0x7f42fdf09332 for type 'uint32_t', which requires 4 byte alignment
0x7f42fdf09332: note: pointer points here
 00 80  00 a0 44 11 00 00 0e 00  00 00 00 30 00 30 00 10  02 10 00 00 0c 00 fc ff  01 30 07 30 12 30
              ^
```

Suggested easiest fix is to use `memcpy` as explained in this blog post https://blog.quarkslab.com/unaligned-accesses-in-cc-what-why-and-solutions-to-do-it-properly.html