### PR TITLE
Fix peaddrconv example compilation failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
           -DBUILD_SHARED_LIBS=${{ matrix.build-shared }} \
           -DPEPARSE_ENABLE_TESTING=ON \
+          -DPEPARSE_ENABLE_EXAMPLES=ON \
           ${SANITIZER_FLAG} \
           ..
         cmake --build .
@@ -119,6 +120,7 @@ jobs:
           -A ${{ matrix.build-arch }} `
           -DBUILD_SHARED_LIBS=${{ matrix.build-shared }} `
           -DPEPARSE_ENABLE_TESTING=ON `
+          -DPEPARSE_ENABLE_EXAMPLES=ON `
           ..
         cmake --build . --config ${{ matrix.build-type }}
     - name: install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
           ${SANITIZER_FLAG} \
           ..
         cmake --build .
+        cmake --build . --target peaddrconv
     - name: test
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
@@ -123,6 +124,7 @@ jobs:
           -DPEPARSE_ENABLE_EXAMPLES=ON `
           ..
         cmake --build . --config ${{ matrix.build-type }}
+        cmake --build . --config ${{ matrix.build-type }} --target peaddrconv
     - name: install
       run: |
         cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,6 @@ jobs:
           ${SANITIZER_FLAG} \
           ..
         cmake --build .
-        cmake --build . --target peaddrconv
     - name: test
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
@@ -124,7 +123,6 @@ jobs:
           -DPEPARSE_ENABLE_EXAMPLES=ON `
           ..
         cmake --build . --config ${{ matrix.build-type }}
-        cmake --build . --config ${{ matrix.build-type }} --target peaddrconv
     - name: install
       run: |
         cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,12 @@ message(STATUS "Build Shared: ${BUILD_SHARED_LIBS} ${BUILD_SHARED_LIBS_MESSAGE}"
 message(STATUS "Build Command Line Tools: ${BUILD_COMMAND_LINE_TOOLS}")
 message(STATUS "Install prefix: ${CMAKE_INSTALL_PREFIX}")
 
+option(PEPARSE_ENABLE_EXAMPLES "Enable building examples" OFF)
+if (PEPARSE_ENABLE_EXAMPLES)
+  message(STATUS "Building Examples")
+  add_subdirectory(examples)
+endif()
+
 option(PEPARSE_ENABLE_TESTING "Enable building tests" OFF)
 if (PEPARSE_ENABLE_TESTING)
   enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ message(STATUS "Install prefix: ${CMAKE_INSTALL_PREFIX}")
 option(PEPARSE_ENABLE_EXAMPLES "Enable building examples" OFF)
 if (PEPARSE_ENABLE_EXAMPLES)
   message(STATUS "Building Examples")
-  add_subdirectory(examples EXCLUDE_FROM_ALL)
+  add_subdirectory(examples)
 endif()
 
 option(PEPARSE_ENABLE_TESTING "Enable building tests" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ message(STATUS "Install prefix: ${CMAKE_INSTALL_PREFIX}")
 option(PEPARSE_ENABLE_EXAMPLES "Enable building examples" OFF)
 if (PEPARSE_ENABLE_EXAMPLES)
   message(STATUS "Building Examples")
-  add_subdirectory(examples)
+  add_subdirectory(examples EXCLUDE_FROM_ALL)
 endif()
 
 option(PEPARSE_ENABLE_TESTING "Enable building tests" OFF)

--- a/README.md
+++ b/README.md
@@ -96,11 +96,7 @@ To run the full test suite with the [Corkami test suite](https://github.com/cork
 
 ## Examples
 
-You can build the included examples by adding `-DPEPARSE_ENABLE_EXAMPLES=ON` during CMake configuration and then by (explicitly) running the `peaddrconv` build target:
-
-```bash
-cmake --build . --target peaddrconv
-```
+You can build the included examples by adding `-DPEPARSE_ENABLE_EXAMPLES=ON` during CMake configuration.
 
 ## Building with Sanitizers
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ You can build the (catch2-based) tests by adding `-DPEPARSE_ENABLE_TESTING=ON` d
 
 To run the full test suite with the [Corkami test suite](https://github.com/corkami/pocs/tree/master/PE), you must clone the submodule with `git submodule update --init`.
 
+## Examples
+
+You can build the included examples by adding `-DPEPARSE_ENABLE_EXAMPLES=ON` during CMake configuration.
+
 ## Building with Sanitizers
 
 If you are familiar with C++ sanitizers and any specific development environment requirements for them (compiler, instrumented standard library, etc.), you can choose to compile with any of the following sanitizers: `Address`, `HWAddress`, `Undefined`, `Memory`, `MemoryWithOrigins`, `Leak`, `Address,Undefined`.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,11 @@ To run the full test suite with the [Corkami test suite](https://github.com/cork
 
 ## Examples
 
-You can build the included examples by adding `-DPEPARSE_ENABLE_EXAMPLES=ON` during CMake configuration.
+You can build the included examples by adding `-DPEPARSE_ENABLE_EXAMPLES=ON` during CMake configuration and then by (explicitly) running the `peaddrconv` build target:
+
+```bash
+cmake --build . --target peaddrconv
+```
 
 ## Building with Sanitizers
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(peaddrconv)

--- a/examples/peaddrconv/CMakeLists.txt
+++ b/examples/peaddrconv/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 project(peaddrconv)
 
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "Default install directory" FORCE)
+  set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}" CACHE PATH "Default install directory" FORCE)
 endif ()
 
 if (MSVC)

--- a/examples/peaddrconv/CMakeLists.txt
+++ b/examples/peaddrconv/CMakeLists.txt
@@ -35,7 +35,9 @@ else ()
   endif ()
 endif ()
 
-find_package(pe-parse REQUIRED)
+if (NOT TARGET pe-parse::pe-parse)
+  find_package(pe-parse REQUIRED)
+endif()
 
 add_executable(${PROJECT_NAME} main.cpp)
 target_link_libraries(${PROJECT_NAME} pe-parse::pe-parse)

--- a/examples/peaddrconv/main.cpp
+++ b/examples/peaddrconv/main.cpp
@@ -53,11 +53,12 @@ bool convertAddress(ParsedPeRef &pe,
     std::uintptr_t highest_offset;
   };
 
-  auto L_getSectionAddressLimits = [](void *N,
-                                      peparse::VA secBase,
-                                      std::string &secName,
-                                      peparse::image_section_header s,
-                                      peparse::bounded_buffer *data) -> int {
+  auto L_getSectionAddressLimits =
+      [](void *N,
+         const peparse::VA &secBase,
+         const std::string &secName,
+         const peparse::image_section_header &s,
+         const peparse::bounded_buffer *data) -> int {
     static_cast<void>(secBase);
     static_cast<void>(secName);
     static_cast<void>(data);
@@ -113,10 +114,10 @@ bool convertAddress(ParsedPeRef &pe,
         };
 
         auto L_inspectSection = [](void *N,
-                                   peparse::VA secBase,
-                                   std::string &secName,
-                                   peparse::image_section_header s,
-                                   peparse::bounded_buffer *data) -> int {
+                                   const peparse::VA &secBase,
+                                   const std::string &secName,
+                                   const peparse::image_section_header &s,
+                                   const peparse::bounded_buffer *data) -> int {
           static_cast<void>(secBase);
           static_cast<void>(secName);
           static_cast<void>(data);
@@ -186,10 +187,10 @@ bool convertAddress(ParsedPeRef &pe,
         };
 
         auto L_inspectSection = [](void *N,
-                                   peparse::VA secBase,
-                                   std::string &secName,
-                                   peparse::image_section_header s,
-                                   peparse::bounded_buffer *data) -> int {
+                                   const peparse::VA &secBase,
+                                   const std::string &secName,
+                                   const peparse::image_section_header &s,
+                                   const peparse::bounded_buffer *data) -> int {
           static_cast<void>(secBase);
           static_cast<void>(secName);
           static_cast<void>(data);

--- a/pe-parser-library/CMakeLists.txt
+++ b/pe-parser-library/CMakeLists.txt
@@ -25,6 +25,7 @@ else()
 endif()
 
 add_library(${PROJECT_NAME} ${PEPARSERLIB_SOURCEFILES})
+add_library(pe-parse::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 if(PEPARSE_LIBRARY_WARNINGS)
 	target_compile_definitions(${PROJECT_NAME} PRIVATE PEPARSE_LIBRARY_WARNINGS=1)


### PR DESCRIPTION
Add option to build examples with main CMake.

Build examples in CI now.

Add target alias with prefix for main pe-parse library.

close #157 