### PR TITLE
Expose more export information, like forwarded export and ordinal

### DIFF
--- a/dump-pe/main.cpp
+++ b/dump-pe/main.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 #include <cstring>
 #include <iomanip>
+#include <ios>
 #include <iostream>
 #include <sstream>
 
@@ -35,19 +36,34 @@ using namespace peparse;
 
 int printExps(void *N,
               const VA &funcAddr,
+              std::uint16_t ordinal,
               const std::string &mod,
-              const std::string &func) {
+              const std::string &func,
+              const std::string &fwd) {
   static_cast<void>(N);
 
   auto address = static_cast<std::uint32_t>(funcAddr);
 
-  std::cout << "EXP: ";
+  // save default formatting
+  std::ios initial(nullptr);
+  initial.copyfmt(std::cout);
+
+  std::cout << "EXP #";
+  std::cout << ordinal;
+  std::cout << ": ";
   std::cout << mod;
   std::cout << "!";
   std::cout << func;
-  std::cout << ": 0x";
-  std::cout << std::hex << address;
+  std::cout << ": ";
+  if (!fwd.empty()) {
+    std::cout << fwd;
+  } else {
+    std::cout << std::showbase << std::hex << address;
+  }
   std::cout << "\n";
+
+  // restore default formatting
+  std::cout.copyfmt(initial);
   return 0;
 }
 
@@ -440,7 +456,7 @@ int main(int argc, char *argv[]) {
     IterSec(p, printSecs, NULL);
     std::cout << "Exports: "
               << "\n";
-    IterExpVA(p, printExps, NULL);
+    IterExpFull(p, printExps, NULL);
 
     // read the first 8 bytes from the entry point and print them
     VA entryPoint;

--- a/pe-parser-library/include/pe-parse/parse.h
+++ b/pe-parser-library/include/pe-parse/parse.h
@@ -229,6 +229,14 @@ typedef int (*iterExp)(void *,
                        const std::string &);
 void IterExpVA(parsed_pe *pe, iterExp cb, void *cbd);
 
+typedef int (*iterExpFull)(void *,
+                           const VA &,
+                           std::uint16_t,
+                           const std::string &,
+                           const std::string &,
+                           const std::string &);
+void IterExpFull(parsed_pe *pe, iterExpFull cb, void *cbd);
+
 // iterate over sections
 typedef int (*iterSec)(void *,
                        const VA &,

--- a/pe-parser-library/include/pe-parse/parse.h
+++ b/pe-parser-library/include/pe-parse/parse.h
@@ -222,13 +222,17 @@ typedef int (*iterSymbol)(void *,
                           const std::uint8_t &);
 void IterSymbols(parsed_pe *pe, iterSymbol cb, void *cbd);
 
-// iterate over the exports
+// iterate over the exports, except forwarded exports
 typedef int (*iterExp)(void *,
                        const VA &,
                        const std::string &,
                        const std::string &);
 void IterExpVA(parsed_pe *pe, iterExp cb, void *cbd);
 
+// iterate over the exports, including forwarded exports
+// export ordinal is also provided as the third argument.
+// VA will be zero if the current export is forwarded,
+// in this case, the last argument (forward string) will be non-empty
 typedef int (*iterExpFull)(void *,
                            const VA &,
                            std::uint16_t,

--- a/pe-parser-library/src/parse.cpp
+++ b/pe-parser-library/src/parse.cpp
@@ -51,8 +51,10 @@ struct importent {
 
 struct exportent {
   VA addr;
+  std::uint16_t ordinal;
   std::string symbolName;
   std::string moduleName;
+  std::string forwardName;
 };
 
 struct reloc {
@@ -1670,23 +1672,37 @@ bool getExports(parsed_pe *p) {
             ((symRVA >= exportDir.VirtualAddress) &&
              (symRVA < exportDir.VirtualAddress + exportDir.Size));
 
+        VA symVA;
+        if (p->peHeader.nt.OptionalMagic == NT_OPTIONAL_32_MAGIC) {
+          symVA = symRVA + p->peHeader.nt.OptionalHeader.ImageBase;
+        } else if (p->peHeader.nt.OptionalMagic == NT_OPTIONAL_64_MAGIC) {
+          symVA = symRVA + p->peHeader.nt.OptionalHeader64.ImageBase;
+        } else {
+          return false;
+        }
+
+        exportent a;
+        a.ordinal = ordinal;
+        a.symbolName = symName;
+        a.moduleName = modName;
+
         if (!isForwarded) {
-          VA symVA;
-          if (p->peHeader.nt.OptionalMagic == NT_OPTIONAL_32_MAGIC) {
-            symVA = symRVA + p->peHeader.nt.OptionalHeader.ImageBase;
-          } else if (p->peHeader.nt.OptionalMagic == NT_OPTIONAL_64_MAGIC) {
-            symVA = symRVA + p->peHeader.nt.OptionalHeader64.ImageBase;
-          } else {
+          a.addr = symVA;
+          a.forwardName.clear();
+        } else {
+          section fwdSec;
+          if (!getSecForVA(p->internal->secs, symVA, fwdSec)) {
             return false;
           }
+          auto fwdOff = static_cast<std::uint32_t>(symVA - fwdSec.sectionBase);
 
-          exportent a;
-
-          a.addr = symVA;
-          a.symbolName = symName;
-          a.moduleName = modName;
-          p->internal->exports.push_back(a);
+          a.addr = 0;
+          if (!readCString(*fwdSec.sectionData, fwdOff, a.forwardName)) {
+            return false;
+          }
         }
+
+        p->internal->exports.push_back(a);
       }
     }
   }
@@ -2533,6 +2549,20 @@ void IterExpVA(parsed_pe *pe, iterExp cb, void *cbd) {
 
   for (exportent &i : l) {
     if (cb(cbd, i.addr, i.moduleName, i.symbolName) != 0) {
+      break;
+    }
+  }
+
+  return;
+}
+
+// iterate over the exports with full information
+void IterExpFull(parsed_pe *pe, iterExpFull cb, void *cbd) {
+  std::vector<exportent> &l = pe->internal->exports;
+
+  for (exportent &i : l) {
+    if (cb(cbd, i.addr, i.ordinal, i.moduleName, i.symbolName, i.forwardName) !=
+        0) {
       break;
     }
   }

--- a/pe-parser-library/src/parse.cpp
+++ b/pe-parser-library/src/parse.cpp
@@ -2548,6 +2548,9 @@ void IterExpVA(parsed_pe *pe, iterExp cb, void *cbd) {
   std::vector<exportent> &l = pe->internal->exports;
 
   for (exportent &i : l) {
+    if (i.addr == 0) {
+      continue;
+    }
     if (cb(cbd, i.addr, i.moduleName, i.symbolName) != 0) {
       break;
     }


### PR DESCRIPTION
I added a new API which allows obtaining more information from PE file's export,
for example the export ordinal or forwarded export information.

```cpp
typedef int (*iterExpFull)(void *,              // context
                           const VA &,          // virtual address, will be null if this is a forwarded export
                           std::uint16_t,       // export ordinal
                           const std::string &, // module
                           const std::string &, // symbol
                           const std::string &);// forward string, will be empty if this is not a forwarded export
void IterExpFull(parsed_pe *pe, iterExpFull cb, void *cbd);
```

The original `IterExpVA` is kept intact for backward compatibility.
Its behavior is not changed (the `iterExpVA` callback will _not_ be invoked on forwarded exports, just like before)