### PR TITLE
Add missing source code from MANIFEST.in to allow sdist to build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include VERSION
 include pepy/README.md
+include pepy/*.cpp
 include pe-parser-library/include/pe-parse/*.h
+include pe-parser-library/src/*.cpp


### PR DESCRIPTION
Adds the following lines to MANIFEST..in to allow setup.py sdist to build correct packages for installation

```
include pepy/*.cpp
include pe-parser-library/src/*.cpp
```

Fixes #183.