### PR TITLE
The ability to allocation and perform further initialization of large PE files.

### DIFF
--- a/pe-parser-library/include/pe-parse/parse.h
+++ b/pe-parser-library/include/pe-parse/parse.h
@@ -158,7 +158,7 @@ bool readDword(bounded_buffer *b, std::uint32_t offset, std::uint32_t &out);
 bool readQword(bounded_buffer *b, std::uint32_t offset, std::uint64_t &out);
 bool readChar16(bounded_buffer *b, std::uint32_t offset, char16_t &out);
 
-bounded_buffer *readFileToFileBuffer(const char *filePath);
+bounded_buffer *readFileToFileBuffer(const char *filePath, bool LargeFile = false);
 bounded_buffer *makeBufferFromPointer(std::uint8_t *data, std::uint32_t sz);
 bounded_buffer *
 splitBuffer(bounded_buffer *b, std::uint32_t from, std::uint32_t to);
@@ -195,7 +195,7 @@ std::string GetPEErrString();
 std::string GetPEErrLoc();
 
 // get a PE parse context from a file
-parsed_pe *ParsePEFromFile(const char *filePath);
+parsed_pe *ParsePEFromFile(const char *filePath, bool LargeFile = false);
 
 parsed_pe *ParsePEFromPointer(std::uint8_t *buffer, std::uint32_t sz);
 parsed_pe *ParsePEFromBuffer(bounded_buffer *buffer);

--- a/pe-parser-library/src/parse.cpp
+++ b/pe-parser-library/src/parse.cpp
@@ -2563,8 +2563,8 @@ parsed_pe *ParsePEFromBuffer(bounded_buffer *buffer) {
   return p;
 }
 
-parsed_pe *ParsePEFromFile(const char *filePath) {
-  auto buffer = readFileToFileBuffer(filePath);
+parsed_pe *ParsePEFromFile(const char *filePath, bool LargeFile) {
+  auto buffer = readFileToFileBuffer(filePath, LargeFile);
 
   if (buffer == nullptr) {
     // err is set by readFileToFileBuffer


### PR DESCRIPTION
Added the ability to read files larger than 40MB at a time. This is necessary, for example, for further initialization of a large PE file, for example, its Imports and the like, which requires a full file in memory. One bool variable was added with default initialization as false, so as not to disrupt the work of projects on older versions or when switching to a new version. The file is loaded by linking two APIs: VirtualAlloc + ReadFile. Thanks for such a wonderful pe parser like this =)