### PR TITLE
set error to PEERR_OPEN when pe file can't be read

### DIFF
--- a/pe-parser-library/src/buffer.cpp
+++ b/pe-parser-library/src/buffer.cpp
@@ -202,6 +202,7 @@ bounded_buffer *readFileToFileBuffer(const char *filePath) {
                          FILE_ATTRIBUTE_NORMAL,
                          nullptr);
   if (h == INVALID_HANDLE_VALUE) {
+    PE_ERR(PEERR_OPEN);
     return nullptr;
   }
 
@@ -209,6 +210,7 @@ bounded_buffer *readFileToFileBuffer(const char *filePath) {
 
   if (fileSize == INVALID_FILE_SIZE) {
     CloseHandle(h);
+    PE_ERR(PEERR_OPEN);
     return nullptr;
   }
 


### PR DESCRIPTION
ParsePEFromFile in parse.cpp returns nullptr without setting error if readFileToFileBuffer in buffer.cpp fails (due to not having the right permissions or the pe file not existing)