### PR TITLE
Preserve the original order of the sections

### DIFF
--- a/pe-parser-library/src/parse.cpp
+++ b/pe-parser-library/src/parse.cpp
@@ -956,11 +956,6 @@ bool getSections(bounded_buffer *b,
     secs.push_back(thisSec);
   }
 
-  std::sort(
-      secs.begin(), secs.end(), [](const section &lhs, const section &rhs) {
-        return lhs.sec.PointerToRawData < rhs.sec.PointerToRawData;
-      });
-
   return true;
 }
 


### PR DESCRIPTION
COFF symbol table references sections by their index. We need to present them to the users in the original order, or they won't be able to use symbols from the COFF table correctly.