### PR TITLE
fix: use resize instead of reserve for UTF-16 conversion buffer

### DIFF
--- a/pe-parser-library/src/unicode_winapi.cpp
+++ b/pe-parser-library/src/unicode_winapi.cpp
@@ -41,13 +41,13 @@ std::string from_utf16(const UCharString &u) {
     return result;
   }
 
-  result.reserve(size);
+  result.resize(size);
   WideCharToMultiByte(CP_UTF8,
                       0,
                       u.data(),
                       static_cast<int>(u.size()),
                       &result[0],
-                      static_cast<int>(result.capacity()),
+                      static_cast<int>(result.size()),
                       nullptr,
                       nullptr);
 


### PR DESCRIPTION
`reserve()` only allocates capacity without changing the string's logical size, so `&result[0]` was passed to WideCharToMultiByte with the buffer size derived from `capacity()` while `size()` remained 0. Switch to `resize()` so the string size matches the allocated buffer, ensuring the converted result is properly visible to callers.