### PR TITLE
Make warnings-as-errors opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: lint
         run: |
           mkdir build && cd build
-          cmake ..
+          cmake -DPEPARSE_WARNINGS_AS_ERRORS=ON ..
           cmake --build . --target peparse_format
           cd .. && git diff --exit-code
 
@@ -81,6 +81,7 @@ jobs:
           -DBUILD_SHARED_LIBS=${{ matrix.build-shared }}
           -DPEPARSE_ENABLE_TESTING=ON
           -DPEPARSE_ENABLE_EXAMPLES=ON
+          -DPEPARSE_WARNINGS_AS_ERRORS=ON
         )
         if [ -n "${SANITIZER_FLAG:-}" ]; then
           cmake_args+=("${SANITIZER_FLAG}")
@@ -163,6 +164,7 @@ jobs:
           -DBUILD_SHARED_LIBS=${{ matrix.build-shared }} `
           -DPEPARSE_ENABLE_TESTING=ON `
           -DPEPARSE_ENABLE_EXAMPLES=ON `
+          -DPEPARSE_WARNINGS_AS_ERRORS=ON `
           $Env:SANITIZER_FLAG `
           ..
         cmake --build . --config ${{ matrix.build-type }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo")
 endif ()
 
+option(PEPARSE_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
+
 include(cmake/compilation_flags.cmake)
 list(APPEND GLOBAL_CXXFLAGS ${DEFAULT_CXX_FLAGS})
 
@@ -59,6 +61,7 @@ add_custom_target(
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "Build Shared: ${BUILD_SHARED_LIBS} ${BUILD_SHARED_LIBS_MESSAGE}")
 message(STATUS "Build Command Line Tools: ${BUILD_COMMAND_LINE_TOOLS}")
+message(STATUS "Warnings as Errors: ${PEPARSE_WARNINGS_AS_ERRORS}")
 message(STATUS "Install prefix: ${CMAKE_INSTALL_PREFIX}")
 
 option(PEPARSE_ENABLE_EXAMPLES "Enable building examples" OFF)

--- a/cmake/compilation_flags.cmake
+++ b/cmake/compilation_flags.cmake
@@ -12,7 +12,7 @@ if (MSVC)
     list(APPEND DEFAULT_CXX_FLAGS /Zi)
   endif ()
 
-  if (CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+  if (PEPARSE_WARNINGS_AS_ERRORS)
     list(APPEND DEFAULT_CXX_FLAGS /WX)
   endif ()
 
@@ -26,19 +26,23 @@ else ()
     -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization
     -Wformat=2 -Winit-self -Wlong-long -Wmissing-declarations -Wmissing-include-dirs -Wcomment
     -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wsign-conversion
-    -Wsign-promo -Wstrict-overflow=5 -Wswitch-default -Wundef -Werror -Wunused -Wuninitialized
+    -Wsign-promo -Wstrict-overflow=5 -Wswitch-default -Wundef -Wunused -Wuninitialized
     -Wno-missing-declarations -Wno-strict-overflow
   )
 
+  if (PEPARSE_WARNINGS_AS_ERRORS)
+    list(APPEND DEFAULT_CXX_FLAGS -Werror)
+  endif ()
+
   if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-  list(APPEND DEFAULT_CXX_FLAGS -gdwarf-2 -g3)
+    list(APPEND DEFAULT_CXX_FLAGS -gdwarf-2 -g3)
   endif ()
 
   if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     list(APPEND DEFAULT_CXX_FLAGS
       -Wno-c++98-compat -Wno-missing-prototypes
       -Wno-missing-variable-declarations -Wno-global-constructors
-      -Wno-exit-time-destructors -Wno-padded -Wno-error
+      -Wno-exit-time-destructors -Wno-padded
     )
   endif ()
 endif ()

--- a/examples/peaddrconv/CMakeLists.txt
+++ b/examples/peaddrconv/CMakeLists.txt
@@ -5,6 +5,8 @@ if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}" CACHE PATH "Default install directory" FORCE)
 endif ()
 
+option(PEPARSE_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
+
 if (MSVC)
   # Default CMAKE_PREFIX_PATH is empty and CMAKE_SYSTEM_PREFIX_PATH is
   # set to a list of Program Files directories, which is a problem because
@@ -12,7 +14,11 @@ if (MSVC)
   # directory on Windows its not found by CMake when performing its search.
   list(APPEND CMAKE_PREFIX_PATH /usr/lib/cmake)
 
-  list(APPEND PEADDRCONV_CXXFLAGS /W4 /WX /analyze)
+  list(APPEND PEADDRCONV_CXXFLAGS /W4 /analyze)
+
+  if (PEPARSE_WARNINGS_AS_ERRORS)
+    list(APPEND PEADDRCONV_CXXFLAGS /WX)
+  endif ()
 
   if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     list(APPEND PEADDRCONV_CXXFLAGS /Zi)
@@ -26,9 +32,13 @@ else ()
     -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization
     -Wformat=2 -Winit-self -Wlong-long -Wmissing-declarations -Wmissing-include-dirs -Wcomment
     -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wsign-conversion
-    -Wsign-promo -Wstrict-overflow=5 -Wswitch-default -Wundef -Werror -Wunused -Wuninitialized
+    -Wsign-promo -Wstrict-overflow=5 -Wswitch-default -Wundef -Wunused -Wuninitialized
     -Wno-missing-declarations
   )
+
+  if (PEPARSE_WARNINGS_AS_ERRORS)
+    list(APPEND PEADDRCONV_CXXFLAGS -Werror)
+  endif ()
 
   if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     list(APPEND PEADDRCONV_CXXFLAGS -gdwarf-2 -g3)


### PR DESCRIPTION
Fixes #159.\n\n## Summary\n- add a PEPARSE_WARNINGS_AS_ERRORS CMake option defaulting OFF\n- gate -Werror and /WX behind the option in the main CMake flags and standalone peaddrconv example\n- keep CI strict by passing -DPEPARSE_WARNINGS_AS_ERRORS=ON in CMake jobs\n\n## Validation\n- actionlint .github/workflows/ci.yml .github/workflows/release.yml\n- git diff --check\n- cmake configure/build with warnings-as-errors OFF\n- cmake configure/build with warnings-as-errors ON\n- ctest --test-dir /private/tmp/pe-parse-issue159-werror-tests --output-on-failure