### PR TITLE
Fix GCC builds by gating Clang-only warning suppressions

### DIFF
--- a/cmake/compilation_flags.cmake
+++ b/cmake/compilation_flags.cmake
@@ -38,7 +38,10 @@ else ()
     list(APPEND DEFAULT_CXX_FLAGS -gdwarf-2 -g3)
   endif ()
 
-  if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  # These suppressions are for Clang-only warnings. GCC rejects
+  # -Wno-missing-prototypes and -Wno-missing-variable-declarations in C++ mode,
+  # which becomes a hard error under -Werror.
+  if (CMAKE_BUILD_TYPE STREQUAL "Debug" AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     list(APPEND DEFAULT_CXX_FLAGS
       -Wno-c++98-compat -Wno-missing-prototypes
       -Wno-missing-variable-declarations -Wno-global-constructors


### PR DESCRIPTION
## What this fixes

CI has been red on every `pe-parse` job since 2026-06-19.

The Debug-only warning-suppression list in `cmake/compilation_flags.cmake` holds Clang-specific flags. GCC recognizes `-Wno-missing-prototypes` and `-Wno-missing-variable-declarations` but rejects them in C++ mode:

```
cc1plus: error: command-line option '-Wno-missing-prototypes' is valid for C/ObjC but not for C++ [-Werror]
```

That list used to end in `-Wno-error`, which neutralized `-Werror` in Debug builds and kept the diagnostic harmless. #220 removed that `-Wno-error` and added `-DPEPARSE_WARNINGS_AS_ERRORS=ON` to CI, so it became fatal and every Linux GCC build failed.

This PR applies those suppressions only when the compiler is Clang (the check also matches AppleClang).

## The failures looked broader than they were

There is one bug here, not nine. The GCC Debug job fails during compilation in ~17s, and matrix `fail-fast` then cancelled every Clang and macOS job before they got past `cmake`. Those jobs are all `cancelled`, not `failure` — none had an independent error.

Two follow-ups worth considering separately:

- Adding `fail-fast: false` to the `pe-parse` matrix would have made this diagnosable at a glance instead of hiding 9 jobs behind one failure.
- #220 also made `-Werror` newly effective in Debug builds on *all* platforms. The macOS legs never completed a build during the red period, so this PR's CI run is the first real signal for them.

## Testing

Ran the Linux half of the CI matrix locally — gcc 15.2 and clang 21.1, Debug/Release, shared/static, ASan+UBSan on Debug, `PEPARSE_WARNINGS_AS_ERRORS=ON`, tests and examples enabled.

All 8 configurations build clean, 15/15 ctest pass, and `dump-pe` runs on `tests/assets/example.exe`. Also confirmed the suppressions still reach Clang Debug builds and are absent from GCC Debug builds. The change is CMake-only, so the `lint` job is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)